### PR TITLE
Add runtime containers c++, driver, go and java

### DIFF
--- a/containers/runtime/README.md
+++ b/containers/runtime/README.md
@@ -1,0 +1,53 @@
+# Runtime Container Images
+
+## [cxx](cxx/)
+
+Base Image: [debian:stretch](https://hub.docker.com/_/debian)
+
+Working Directory: `/src/workspace`
+
+Entrypoint: `bash`
+
+Official Docker Image for the Debian distribution, decorated with autoconf,
+build-essential, clang, git, make, libtool, libgflags-dev and pkg-config.
+
+## [driver](driver/)
+
+Base Image: [debian:stretch](https://hub.docker.com/_/debian)
+
+Working Directory: `/src/workspace`
+
+Entrypoint: `bash`
+
+Official Docker Image for the Debian distribution, decorated with autoconf,
+build-essential, clang, git, make, libtool, libgflags-dev and pkg-config.
+
+Includes gnupg, apt-transport-https, ca-certificates, python3-dev, python3-pip,
+python3-setuptools, python3-yamlz and the Google Cloud SDK. Also installs the
+protobuf, google-api-python-client, oauth2client, google-auth-oauthlib,
+tabulate, six, pyasn1_modules and pyasn1 python packages.
+
+## [go](go/)
+
+Base Image: [golang:1.14](https://hub.docker.com/_/golang)
+
+Entrypoint: `bash`
+
+Working Directory: `/src/workspace`
+
+Official Docker Image for the Go Programming Language.
+
+Additionally installs bash, curl, git, make and time for debugging.
+
+## [java](java/)
+
+Base Image: [openjdk:8](https://hub.docker.com/_/openjdk)
+
+Entrypoint: `bash`
+
+Working Directory: `/src/workspace`
+
+Official Docker Image of OpenJDK 8 on Debian. This is not Oracle's OpenJDK
+container.
+
+Additionally installs bash, curl, git and time for debugging.

--- a/containers/runtime/README.md
+++ b/containers/runtime/README.md
@@ -1,53 +1,22 @@
 # Runtime Container Images
 
+These container images provide the environments for the load tests. They are
+derivatives of the [interop test images](https://github.com/grpc/grpc/tree/master/tools/dockerfile/interoptest/).
+
 ## [cxx](cxx/)
 
-Base Image: [debian:stretch](https://hub.docker.com/_/debian)
-
-Working Directory: `/src/workspace`
-
-Entrypoint: `bash`
-
-Official Docker Image for the Debian distribution, decorated with autoconf,
-build-essential, clang, git, make, libtool, libgflags-dev and pkg-config.
+Base Image: [Debian Stable](https://hub.docker.com/_/debian)
 
 ## [driver](driver/)
 
-Base Image: [debian:stretch](https://hub.docker.com/_/debian)
+Base Image: [Debian Stable](https://hub.docker.com/_/debian)
 
-Working Directory: `/src/workspace`
-
-Entrypoint: `bash`
-
-Official Docker Image for the Debian distribution, decorated with autoconf,
-build-essential, clang, git, make, libtool, libgflags-dev and pkg-config.
-
-Includes gnupg, apt-transport-https, ca-certificates, python3-dev, python3-pip,
-python3-setuptools, python3-yamlz and the Google Cloud SDK. Also installs the
-protobuf, google-api-python-client, oauth2client, google-auth-oauthlib,
-tabulate, six, pyasn1_modules and pyasn1 python packages.
+Differs from [cxx](cxx/) by adding Google Cloud SDK and python3 interpreter.
 
 ## [go](go/)
 
-Base Image: [golang:1.14](https://hub.docker.com/_/golang)
-
-Entrypoint: `bash`
-
-Working Directory: `/src/workspace`
-
-Official Docker Image for the Go Programming Language.
-
-Additionally installs bash, curl, git, make and time for debugging.
+Base Image: [Golang Image](https://hub.docker.com/_/golang)
 
 ## [java](java/)
 
-Base Image: [openjdk:8](https://hub.docker.com/_/openjdk)
-
-Entrypoint: `bash`
-
-Working Directory: `/src/workspace`
-
-Official Docker Image of OpenJDK 8 on Debian. This is not Oracle's OpenJDK
-container.
-
-Additionally installs bash, curl, git and time for debugging.
+Base Image: [Docker OpenJDK Image](https://hub.docker.com/_/openjdk)

--- a/containers/runtime/cxx/Dockerfile
+++ b/containers/runtime/cxx/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
-
-FROM debian:stretch
+FROM debian:buster
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
@@ -27,8 +25,7 @@ RUN apt-get update && apt-get install -y \
   make \
   libtool \
   libgflags-dev \
-  pkg-config
-
-RUN apt-get clean
+  pkg-config && \
+  apt-get clean
 
 CMD ["bash"]

--- a/containers/runtime/cxx/Dockerfile
+++ b/containers/runtime/cxx/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
+
+FROM debian:stretch
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  build-essential \
+  clang \
+  git \
+  make \
+  libtool \
+  libgflags-dev \
+  pkg-config
+
+RUN apt-get clean
+
+CMD ["bash"]

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
-
-FROM debian:stretch
+FROM debian:buster
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
@@ -31,19 +29,17 @@ RUN apt-get update && apt-get install -y \
   pkg-config \
   gnupg \
   apt-transport-https \
-  ca-certificates
-
-RUN apt-get update && apt-get install -y \
+  ca-certificates \
   python3-dev \
   python3-pip \
   python3-setuptools \
-  python3-yaml
+  python3-yaml && \
+  apt-get clean
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
   tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
-
-RUN apt-get clean
+  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y && \
+  apt-get clean
 
 RUN pip3 install \
   protobuf \

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
+
+FROM debian:stretch
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  build-essential \
+  clang \
+  curl \
+  git \
+  make \
+  libtool \
+  libgflags-dev \
+  pkg-config \
+  gnupg \
+  apt-transport-https \
+  ca-certificates
+
+RUN apt-get update && apt-get install -y \
+  python3-dev \
+  python3-pip \
+  python3-setuptools \
+  python3-yaml
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+
+RUN apt-get clean
+
+RUN pip3 install \
+  protobuf \
+  google-api-python-client \
+  oauth2client \
+  google-auth-oauthlib \
+  tabulate \
+  six==1.10.0 \
+  pyasn1_modules==0.2.2 \
+  pyasn1==0.4.2
+
+CMD ["bash"]

--- a/containers/runtime/go/Dockerfile
+++ b/containers/runtime/go/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
-
 FROM golang:1.14
 
 RUN mkdir -p /src/workspace
@@ -21,8 +19,7 @@ WORKDIR /src/workspace
 
 RUN apt-get update && apt-get install -y \
   git \
-  make
-
-RUN apt-get clean
+  make && \
+  apt-get clean
 
 CMD ["bash"]

--- a/containers/runtime/go/Dockerfile
+++ b/containers/runtime/go/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
+
+FROM golang:1.14
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  git \
+  make
+
+RUN apt-get clean
+
+CMD ["bash"]

--- a/containers/runtime/java/Dockerfile
+++ b/containers/runtime/java/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
+
+FROM openjdk:8
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  bash \
+  curl \
+  git \
+  time
+
+RUN apt-get clean
+
+CMD ["bash"]

--- a/containers/runtime/java/Dockerfile
+++ b/containers/runtime/java/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WHEN EDITING THIS FILE, ALSO UPDATE ../README.md TO REFLECT CHANGES!
-
 FROM openjdk:8
 
 RUN mkdir -p /src/workspace
@@ -23,8 +21,7 @@ RUN apt-get update && apt-get install -y \
   bash \
   curl \
   git \
-  time
-
-RUN apt-get clean
+  time && \
+  apt-get clean
 
 CMD ["bash"]


### PR DESCRIPTION
This change adds Dockerfiles for the runtime containers of the C++, Go and Java workers, as well as, the C++ driver. In addition, it adds a README.md file, so developers can quickly see what the images contain.

@jtattermusch These use the official Docker images for OpenJDK and Go (see email). If it is better for security or control to just install off Debian, I'm happy to change them. Thanks.