### PR TITLE
Add clone init container for git checkouts

### DIFF
--- a/containers/init/clone/Dockerfile
+++ b/containers/init/clone/Dockerfile
@@ -14,8 +14,7 @@
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install -y git
-RUN apt-get clean
+RUN apt-get update && apt-get install -y git && apt-get clean
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/init/clone/Dockerfile
+++ b/containers/init/clone/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y git
+RUN apt-get clean
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN mkdir -p /src/clone
+COPY . /src/clone
+RUN chmod a+x /src/clone/clone.sh
+
+CMD ["/src/clone/clone.sh"]

--- a/containers/init/clone/Dockerfile
+++ b/containers/init/clone/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && apt-get install -y git
 RUN apt-get clean

--- a/containers/init/clone/README.md
+++ b/containers/init/clone/README.md
@@ -1,0 +1,12 @@
+# Clone
+
+Clone is a container that clones a GitHub repository into its working directory
+and checks out a specific commit, branch or tag. It is intended to be used as an
+init container with a volume mount.
+
+The environment variables `$CLONE_REPO` and `$CLONE_GIT_REF` set the address of
+the repository and the commit, branch or tag to checkout. `$CLONE_REPO` should
+be a URL with a `.git` extension, like:
+`https://github.com/grpc/test-infra.git`.
+
+This version of clone does not support SSH and is tested with HTTP/HTTPS.

--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git clone --recursive $CLONE_REPO /src/workspace
+if [[ $? -ne 0 ]]; then
+  echo "Failed to clone repository at \"$CLONE_REPO\""
+  exit $?
+fi
+
+git checkout $CLONE_GIT_REF
+if [[ $? -ne 0 ]]; then
+  echo "Failed to checkout git-ref \"$CLONE_GIT_REF\""
+  echo "The git-ref must be a commit hash, branch or tag"
+  exit $?
+fi

--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -13,17 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
 git clone --recursive $CLONE_REPO /src/workspace
-code=$?
-if [[ $code -ne 0 ]]; then
-  echo "Failed to clone repository at \"$CLONE_REPO\""
-  exit $code
-fi
-
 git checkout $CLONE_GIT_REF
-code=$?
-if [[ $code -ne 0 ]]; then
-  echo "Failed to checkout git-ref \"$CLONE_GIT_REF\""
-  echo "The git-ref must be a commit hash, branch or tag"
-  exit $code
-fi

--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 git clone --recursive $CLONE_REPO /src/workspace
-if [[ $? -ne 0 ]]; then
+code=$?
+if [[ $code -ne 0 ]]; then
   echo "Failed to clone repository at \"$CLONE_REPO\""
-  exit $?
+  exit $code
 fi
 
 git checkout $CLONE_GIT_REF
-if [[ $? -ne 0 ]]; then
+code=$?
+if [[ $code -ne 0 ]]; then
   echo "Failed to checkout git-ref \"$CLONE_GIT_REF\""
   echo "The git-ref must be a commit hash, branch or tag"
-  exit $?
+  exit $code
 fi


### PR DESCRIPTION
This commit adds a docker container that can clone a git repository and checkout a specific commit, branch or tag. The clone and checkout occur at runtime.

This is intended to become an init container. It will serve as part of the pipeline to checkout, build and run tests. Since its logic is fairly straight-forward, it uses a shell script. The image is based off of `debian`, installing git.