### PR TITLE
Fix clone init container idempotency

### DIFF
--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -14,5 +14,6 @@
 # limitations under the License.
 
 set -ex
+rm -fr /src/workspace/*
 git clone --recursive $CLONE_REPO /src/workspace
 git checkout $CLONE_GIT_REF

--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 set -ex
-rm -fr /src/workspace/*
-git clone --recursive $CLONE_REPO /src/workspace
+
+cd /src/workspace
+ls -A | xargs -r rm -fr
+git clone --recursive $CLONE_REPO .
 git checkout $CLONE_GIT_REF


### PR DESCRIPTION
According to the Kubernetes documentation for [Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#detailed-behavior):
> Because init containers can be restarted, retried, or re-executed, init container code should be idempotent. In particular, code that writes to files on EmptyDirs should be prepared for the possibility that an output file already exists.

The clone container does not address the situation where the /src/workspace directory exists and is not empty. This change adds a
command to remove the pre-existing contents of the /src/workspace directory. This removal ensures that the output of the container is equivalent, regardless of pre-existing runs.