### PR TITLE
Fix lint and fmt checks in GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,8 +43,11 @@ jobs:
 
     - name: Check for format and lint issues
       run: |
-        test -z $(gofmt -s -d -l .) # see https://github.com/golang/go/issues/24230
-        golint ./...
+        # see https://github.com/golang/go/issues/24230
+        fmtcode="$(gofmt -s -d -l .)"
+        echo $fmtcode && test -z "$fmtcode"
+        lintcode="$(golint ./...)"
+        echo $lintcode && test -z "$lintcode"
 
     - name: Check imports
       run: goimports -l .


### PR DESCRIPTION
The exit codes for the fmt and golint checks were not being reflected in the status of a build. In addition, problems were not being properly listed. This change fixes both issues by wrapping with a `test -z` command and echoing the contents.