### PR TITLE
Fix code generation comment

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -21,7 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NOTE: AFTER EDITS, YOU MUST RUN `make` TO REGENERATE CODE.
+// NOTE: CODE IS GENERATED FROM THIS FILE!
+// PLEASE RUN `make manifests` AND `make` AFTER EDITING.
 
 // Clone defines expectations regarding which repository and snapshot the test
 // should use.

--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -21,8 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NOTE: CODE IS GENERATED FROM THIS FILE!
-// PLEASE RUN `make manifests` AND `make` AFTER EDITING.
+// NOTE: AFTER EDITING, RUN `make manifests` AND `make` TO REGENERATE CODE.
 
 // Clone defines expectations regarding which repository and snapshot the test
 // should use.

--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -21,7 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NOTE: AFTER EDITING, RUN `make manifests` AND `make` TO REGENERATE CODE.
+// NOTE: AFTER EDITS, YOU MUST RUN `make manifests` AND `make` TO REGENERATE
+// CODE.
 
 // Clone defines expectations regarding which repository and snapshot the test
 // should use.


### PR DESCRIPTION
Whenever the api/v1/loadtest_types.go file is changed, the developer must regenerate the YAML files. Previously, this comment did not mention rebuilding the manifests. This change rewords it to include both the `make all` and `make manifests` targets.