### PR TITLE
Add load test controller scaffold and test environment

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +29,8 @@ import (
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/pkg/defaults"
 )
+
+const reconcileTimeout = 1 * time.Minute
 
 // LoadTestReconciler reconciles a LoadTest object
 type LoadTestReconciler struct {
@@ -43,11 +47,58 @@ type LoadTestReconciler struct {
 // with its declared spec. This may mean provisioning resources, doing nothing
 // or handling the termination of its pods.
 func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("loadtest", req.NamespacedName)
+	log := r.Log.WithValues("loadtest", req.NamespacedName)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 
-	// your logic here
+	// Fetch the current state of the world.
 
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		log.Error(err, "failed to list nodes")
+		// attempt to requeue with exponential back-off
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(req.Namespace)); err != nil {
+		log.Error(err, "failed to list pods", "namespace", req.Namespace)
+		// attempt to requeue with exponential back-off
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	var loadtests grpcv1.LoadTestList
+	if err := r.List(ctx, &loadtests); err != nil {
+		log.Error(err, "failed to list loadtests")
+		// attempt to requeue with exponential back-off
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	var loadtest grpcv1.LoadTest
+	if err := r.Get(ctx, req.NamespacedName, &loadtest); err != nil {
+		log.Error(err, "failed to get loadtest", "name", req.NamespacedName)
+		// do not requeue, may have been garbage collected
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the loadtest has terminated.
+
+	// TODO: Do nothing if the loadtest has terminated.
+
+	// Check the status of any running pods.
+
+	// TODO: Add method to get list of owned pods and method to check their status.
+
+	// Create any missing pods that the loadtest needs.
+
+	// TODO: Add method to detect what is missing on the load test.
+	// TODO: Add logic to schedule the next missing pod.
+
+	// PLACEHOLDERS!
+	_ = nodes
+	_ = pods
+	_ = loadtests
+	_ = loadtest
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -1,0 +1,19 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	//corev1 "k8s.io/api/core/v1"
+	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Load Test Controller", func() {
+	It("placeholder", func() {
+		time.Sleep(5 * time.Second)
+		err := k8sClient.Create(context.Background(), newLoadTest())
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,13 +17,21 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -40,6 +48,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var stop chan struct{}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -65,17 +74,159 @@ var _ = BeforeSuite(func(done Done) {
 	err = grpcv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	reconciler := &LoadTestReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+		Log:    ctrl.Log.WithName("controller").WithName("LoadTest"),
+	}
+	err = reconciler.SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).ToNot(HaveOccurred())
+	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
+
+	stop = make(chan struct{})
+	go func() {
+		err := k8sManager.Start(stop)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	for _, node := range nodes {
+		Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+	}
 
 	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	close(stop)
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
+
+var pools = map[string]int{
+	"drivers":   3,
+	"workers-a": 5,
+	"workers-b": 7,
+}
+
+var nodes = func() []*corev1.Node {
+	var items []*corev1.Node
+
+	for pool, count := range pools {
+		for i := 0; i < count; i++ {
+			items = append(items, &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node-%s-%d", pool, i),
+					Labels: map[string]string{
+						"pool": pool,
+					},
+				},
+			})
+		}
+	}
+
+	return items
+}()
+
+func newLoadTest() *grpcv1.LoadTest {
+	cloneImage := "docker.pkg.github.com/grpc/test-infra/clone"
+	cloneRepo := "https://github.com/grpc/grpc.git"
+	cloneGitRef := "master"
+
+	buildImage := "l.gcr.io/google/bazel:latest"
+	buildCommand := []string{"bazel"}
+	buildArgs := []string{"build", "//test/cpp/qps:qps_worker"}
+
+	driverImage := "docker.pkg.github.com/grpc/test-infra/driver"
+	runImage := "docker.pkg.github.com/grpc/test-infra/cxx"
+	runCommand := []string{"bazel-bin/test/cpp/qps/qps_worker"}
+	clientRunArgs := []string{"--driver_port=10000"}
+	serverRunArgs := append(clientRunArgs, "--server_port=10010")
+
+	bigQueryTable := "grpc-testing.e2e_benchmark.foobarbuzz"
+
+	driverPool := "drivers"
+	workerPool := "workers-8core"
+
+	return &grpcv1.LoadTest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-loadtest",
+			Namespace: "default",
+		},
+
+		Spec: grpcv1.LoadTestSpec{
+			Driver: &grpcv1.Driver{
+				Component: grpcv1.Component{
+					Language: "cxx",
+					Pool:     &driverPool,
+					Run: grpcv1.Run{
+						Image: &driverImage,
+					},
+				},
+			},
+
+			Servers: []grpcv1.Server{
+				{
+					Component: grpcv1.Component{
+						Language: "cxx",
+						Pool:     &workerPool,
+						Clone: &grpcv1.Clone{
+							Image:  &cloneImage,
+							Repo:   &cloneRepo,
+							GitRef: &cloneGitRef,
+						},
+						Build: &grpcv1.Build{
+							Image:   &buildImage,
+							Command: buildCommand,
+							Args:    buildArgs,
+						},
+						Run: grpcv1.Run{
+							Image:   &runImage,
+							Command: runCommand,
+							Args:    serverRunArgs,
+						},
+					},
+				},
+			},
+
+			Clients: []grpcv1.Client{
+				{
+					Component: grpcv1.Component{
+						Language: "cxx",
+						Pool:     &workerPool,
+						Clone: &grpcv1.Clone{
+							Image:  &cloneImage,
+							Repo:   &cloneRepo,
+							GitRef: &cloneGitRef,
+						},
+						Build: &grpcv1.Build{
+							Image:   &buildImage,
+							Command: buildCommand,
+							Args:    buildArgs,
+						},
+						Run: grpcv1.Run{
+							Image:   &runImage,
+							Command: runCommand,
+							Args:    clientRunArgs,
+						},
+					},
+				},
+			},
+
+			Results: &grpcv1.Results{
+				BigQueryTable: &bigQueryTable,
+			},
+
+			Scenarios: []grpcv1.Scenario{
+				{Name: "cpp-example-scenario"},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This commit adds a scaffold for the load test controller logic. In addition, it configures a test suite using envtest and fake node pools.

The test environment is similar to the Microsoft examples recommended by kubebuilder in its book: https://book.kubebuilder.io/reference/writing-tests.html. They are virtually the only documentation out there.