### PR TITLE
Generate unique component names when unspecified

### DIFF
--- a/pkg/defaults/loadtest_defaults.go
+++ b/pkg/defaults/loadtest_defaults.go
@@ -1,6 +1,7 @@
 package defaults
 
 import (
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
@@ -28,6 +29,10 @@ func CopyWithDefaults(d *Defaults, loadtest *grpcv1.LoadTest) (*grpcv1.LoadTest,
 		}
 	}
 
+	if spec.Driver.Name == nil {
+		setRandomName(&spec.Driver.Component)
+	}
+
 	if spec.Driver.Pool == nil {
 		spec.Driver.Pool = &d.DriverPool
 	}
@@ -53,6 +58,10 @@ func CopyWithDefaults(d *Defaults, loadtest *grpcv1.LoadTest) (*grpcv1.LoadTest,
 
 	var servers []grpcv1.Server
 	for _, server := range spec.Servers {
+		if server.Name == nil {
+			setRandomName(&server.Component)
+		}
+
 		if server.Pool == nil {
 			server.Pool = &d.WorkerPool
 		}
@@ -93,6 +102,10 @@ func CopyWithDefaults(d *Defaults, loadtest *grpcv1.LoadTest) (*grpcv1.LoadTest,
 
 	var clients []grpcv1.Client
 	for _, client := range spec.Clients {
+		if client.Name == nil {
+			setRandomName(&client.Component)
+		}
+
 		if client.Pool == nil {
 			client.Pool = &d.WorkerPool
 		}
@@ -133,3 +146,15 @@ func CopyWithDefaults(d *Defaults, loadtest *grpcv1.LoadTest) (*grpcv1.LoadTest,
 
 	return test, nil
 }
+
+// setRandomName generates a new globally unique name and sets it on a
+// component.
+//
+// Note this function will panic if given a nil pointer. The caller should
+// ensure it is not passed nil arguments. This is meant to be an internal helper
+// to CopyWithDefaults, and it is likely to be inlined by the Go compiler.
+func setRandomName(component *grpcv1.Component) {
+	name := uuid.New().String()
+	component.Name = &name
+}
+

--- a/pkg/defaults/loadtest_defaults.go
+++ b/pkg/defaults/loadtest_defaults.go
@@ -157,4 +157,3 @@ func setRandomName(component *grpcv1.Component) {
 	name := uuid.New().String()
 	component.Name = &name
 }
-

--- a/pkg/defaults/loadtest_defaults_test.go
+++ b/pkg/defaults/loadtest_defaults_test.go
@@ -304,7 +304,7 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 		Spec: grpcv1.LoadTestSpec{
 			Driver: &grpcv1.Driver{
 				Component: grpcv1.Component{
-					Name: &driverComponentName,
+					Name:     &driverComponentName,
 					Language: "cxx",
 					Pool:     &driverPool,
 					Run: grpcv1.Run{
@@ -316,7 +316,7 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 			Servers: []grpcv1.Server{
 				{
 					Component: grpcv1.Component{
-						Name: &serverComponentName,
+						Name:     &serverComponentName,
 						Language: "cxx",
 						Pool:     &workerPool,
 						Clone: &grpcv1.Clone{
@@ -341,7 +341,7 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 			Clients: []grpcv1.Client{
 				{
 					Component: grpcv1.Component{
-						Name: &clientComponentName,
+						Name:     &clientComponentName,
 						Language: "cxx",
 						Pool:     &workerPool,
 						Clone: &grpcv1.Clone{

--- a/pkg/defaults/loadtest_defaults_test.go
+++ b/pkg/defaults/loadtest_defaults_test.go
@@ -71,6 +71,12 @@ var _ = Describe("CopyWithDefaults", func() {
 	})
 
 	Context("driver", func() {
+		It("sets default name when unspecified", func() {
+			loadtest.Spec.Driver.Name = nil
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Spec.Driver.Name).ToNot(BeNil())
+		})
+
 		It("sets default when nil", func() {
 			loadtest.Spec.Driver = nil
 			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
@@ -138,6 +144,23 @@ var _ = Describe("CopyWithDefaults", func() {
 	})
 
 	Context("servers", func() {
+		It("sets default name when unspecified", func() {
+			loadtest.Spec.Servers[0].Name = nil
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Spec.Servers[0].Name).ToNot(BeNil())
+		})
+
+		It("sets default name that is unique", func() {
+			server2 := loadtest.Spec.Servers[0].DeepCopy()
+			loadtest.Spec.Servers = append(loadtest.Spec.Servers, *server2)
+
+			loadtest.Spec.Servers[0].Name = nil
+			loadtest.Spec.Servers[1].Name = nil
+
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Spec.Servers[0].Name).ToNot(Equal(copy.Spec.Servers[1].Name))
+		})
+
 		It("sets clone image when missing", func() {
 			loadtest.Spec.Servers[0].Clone.Image = nil
 			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
@@ -187,6 +210,23 @@ var _ = Describe("CopyWithDefaults", func() {
 	})
 
 	Context("clients", func() {
+		It("sets default name when unspecified", func() {
+			loadtest.Spec.Clients[0].Name = nil
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Spec.Clients[0].Name).ToNot(BeNil())
+		})
+
+		It("sets default name that is unique", func() {
+			client2 := loadtest.Spec.Clients[0].DeepCopy()
+			loadtest.Spec.Clients = append(loadtest.Spec.Clients, *client2)
+
+			loadtest.Spec.Clients[0].Name = nil
+			loadtest.Spec.Clients[1].Name = nil
+
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Spec.Clients[0].Name).ToNot(Equal(copy.Spec.Clients[1].Name))
+		})
+
 		It("sets clone image when missing", func() {
 			loadtest.Spec.Clients[0].Clone.Image = nil
 			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
@@ -256,10 +296,15 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 	driverPool := "drivers"
 	workerPool := "workers-8core"
 
+	driverComponentName := "driver"
+	serverComponentName := "server"
+	clientComponentName := "client-1"
+
 	return &grpcv1.LoadTest{
 		Spec: grpcv1.LoadTestSpec{
 			Driver: &grpcv1.Driver{
 				Component: grpcv1.Component{
+					Name: &driverComponentName,
 					Language: "cxx",
 					Pool:     &driverPool,
 					Run: grpcv1.Run{
@@ -271,6 +316,7 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 			Servers: []grpcv1.Server{
 				{
 					Component: grpcv1.Component{
+						Name: &serverComponentName,
 						Language: "cxx",
 						Pool:     &workerPool,
 						Clone: &grpcv1.Clone{
@@ -295,6 +341,7 @@ var completeLoadTest = func() *grpcv1.LoadTest {
 			Clients: []grpcv1.Client{
 				{
 					Component: grpcv1.Component{
+						Name: &clientComponentName,
 						Language: "cxx",
 						Pool:     &workerPool,
 						Clone: &grpcv1.Clone{


### PR DESCRIPTION
Each driver, server and client component must have a relatively unique name. This means their name cannot be identical to another component with the same role in the same load test. Previously, this name was manually provided.

This change generates unique names for components where names are not manually set. To ensure relative uniqueness, it uses Google's UUID library to generate a token.