### PR TITLE
Build driver code in driver Dockerfile

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -14,8 +14,29 @@
 
 FROM debian:buster
 
-RUN mkdir -p /src/workspace
+ARG REPOSITORY=grpc/grpc
+ARG GITREF=master
+
+RUN apt-get update && apt-get install -y git
+
+RUN mkdir -p /grpc/grpc
+WORKDIR /grpc/grpc
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+
+FROM l.gcr.io/google/bazel:0.17.1
+
+COPY --from=0 /grpc/grpc /src/workspace
+RUN mkdir -p /tmp/build_output
 WORKDIR /src/workspace
+RUN bazel --output_user_root=/tmp/build_output build //test/cpp/qps:qps_json_driver
+
+FROM debian:buster
+
+WORKDIR /grpc/grpc
+COPY --from=1 /tmp/build_output /tmp/build_output
+COPY --from=1 /src/workspace .
 
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -29,17 +50,19 @@ RUN apt-get update && apt-get install -y \
   pkg-config \
   gnupg \
   apt-transport-https \
-  ca-certificates \
+  ca-certificates
+
+RUN apt-get update && apt-get install -y \
   python3-dev \
   python3-pip \
   python3-setuptools \
-  python3-yaml && \
-  apt-get clean
+  python3-yaml
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
   tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y && \
-  apt-get clean
+  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+
+RUN apt-get clean
 
 RUN pip3 install \
   protobuf \
@@ -51,4 +74,11 @@ RUN pip3 install \
   pyasn1_modules==0.2.2 \
   pyasn1==0.4.2
 
-CMD ["bash"]
+COPY . .
+RUN chmod a+x run.sh
+
+ENV QPS_WORKERS=""
+ENV SCENARIOS_FILE="example.json"
+ENV BQ_RESULT_TABLE=""
+
+CMD ["./run.sh"]

--- a/containers/runtime/driver/example.json
+++ b/containers/runtime/driver/example.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [{
+    "name": "example"
+  }]
+}

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
+  --scenario_result_file='scenario_result.json'
+
+if [ "$BQ_RESULT_TABLE" != "" ]
+then
+  python3 tools/run_tests/performance/bq_upload_result.py --bq_result_table="$BQ_RESULT_TABLE"
+fi
+


### PR DESCRIPTION
The previous version of the driver image prepared an environment for running the driver but did not include a compiled version of the driver in the container image. The driver code would be built at runtime. However, this would result in slow Java and Go tests, since the driver takes much longer to build than Java or Go's workers.

This change compiles the latest driver from the master branch of grpc/grpc whenever the container image is rebuilt. This allows a driver to start almost instantly!

In addition, it uses the `--scenario_file` flag to accept a JSON file as an argument. This *differs* from the prototype, because it moves towards mounted volumes over environment variables. Environment variables are problematic when the JSON is not minified. Whitespace caused the driver to parse the JSON as separate arguments. In addition, there could be limits to the maximum characters in an environment variable or a single command. Volumes allow kubernetes to mount a file with the JSON that the driver can parse, circumventing these issues. It is also compatible with #21. 