### PR TITLE
Add ready init container

### DIFF
--- a/containers/init/ready/Dockerfile
+++ b/containers/init/ready/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14
+
+RUN mkdir -p /src/ready
+WORKDIR /src/ready
+
+COPY . .
+RUN go install ./containers/init/ready
+
+CMD ["ready"]

--- a/containers/init/ready/README.md
+++ b/containers/init/ready/README.md
@@ -1,0 +1,51 @@
+# Ready
+
+Ready is a container that waits for a list of pods with specific labels to
+become available. It exits successfully when all pods are ready, writing a
+comma-separated list of their IP addresses to a file. It exits unsuccessfully if
+a timeout was exceeded before all pods were ready.
+
+## Usage
+
+The container relies on command line arguments to specify the labels pods should
+match. These arguments are in the form of `key=value,key2=value2` where commas
+are treated as `AND`s and spaces delineate separate pods. For example,
+
+```
+go run ready.go role=server,proxy=envoy role=client role=client
+```
+
+Will wait for three pods:
+
+1.  pod with labels role=server AND proxy=envoy
+2.  pod with label role=client
+3.  another pod with label role=client
+
+Meanwhile, users can set environment variables to override some defaults:
+
+-   `$READY_TIMEOUT` specifies the maximum amount of time the container should
+    wait for pods to become ready. This time is specified in a human-readable
+    format that is parsable by Go's
+    [time.ParseDuration](https://pkg.go.dev/time?tab=doc#ParseDuration). For
+    example, "1m" represents 1 minute and "3h" represents 3 hours. If this
+    timeout is reached before the pods are ready, the container will exit with a
+    code of 1.
+
+-   `$READY_OUTPUT_FILE` specifies the absolute path of the output file. This
+    will contain a comma-separated list of IP addresses for matching pods. This
+    defaults to /tmp/loadtest_workers.
+
+-   `$KUBE_CONFIG` specifies the path to a Kubernetes config file. This can be
+    omitted when running in a Kubernetes cluster. If running outside a cluster,
+    this is required. It will likely be ~/.kube/config when developing locally
+    on Linux.
+
+## Building
+
+This image requires some utility code outside of this directory. Therefore, the
+test-infra/ directory should be used as the build context:
+
+```
+cd ../../../  # should be test-infra/
+docker build -f containers/init/ready/Dockerfile .
+```

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grpc/test-infra/internal/kubehelpers"
+)
+
+// TimeoutEnv is the name of the environment variable that will contain the
+// maximum amount of time to wait for pods to become ready.
+const TimeoutEnv = "READY_TIMEOUT"
+
+// DefaultTimeout specifies the amount of time to wait for ready pods if the
+// environment variable specified by the TimeoutEnv constant is not set.
+const DefaultTimeout = 5 * time.Minute
+
+// OutputFileEnv is the optional name of the file where the executable should
+// write a comma-separated list of IP addresses. If this environment variable is
+// unset, DefaultOutputFile will be used as the default.
+const OutputFileEnv = "READY_OUTPUT_FILE"
+
+// DefaultOutputFile is the name of the default file where the executable should
+// write the comma-separated list of IP addresses.
+const DefaultOutputFile = "/tmp/loadtest_workers"
+
+// KubeConfigEnv is the name of the environment variable that may contain a
+// path to a kubeconfig file. This environment variable does not need to be set
+// when the container runs on a node in a Kubernetes cluster.
+const KubeConfigEnv = "KUBE_CONFIG"
+
+// pollInterval specifies the amount of time between subsequent requests to the
+// Kubernetes API for a list of pods.
+const pollInterval = 3 * time.Second
+
+// PodLister lists pods known to a Kubernetes cluster.
+type PodLister interface {
+	List(metav1.ListOptions) (*corev1.PodList, error)
+}
+
+// parseSelectors accepts a slice of strings and converts them into Kubernetes
+// selectors. It returns an error if any of the strings is not a valid selector.
+func parseSelectors(args []string) ([]labels.Selector, error) {
+	var selectors []labels.Selector
+
+	for i, arg := range args {
+		selector, err := labels.Parse(arg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse selector #%d (%s): %v", i+1, arg, err)
+		}
+
+		selectors = append(selectors, selector)
+	}
+
+	return selectors, nil
+}
+
+// isPodReady returns true if the pod has been assigned an IP address and all of
+// its containers are ready.
+func isPodReady(pod *corev1.Pod) bool {
+	spec := &pod.Spec
+	status := &pod.Status
+
+	if status.PodIP == "" {
+		return false
+	}
+
+	if len(spec.Containers) != len(status.ContainerStatuses) {
+		return false
+	}
+
+	for _, cstat := range status.ContainerStatuses {
+		if !cstat.Ready {
+			return false
+		}
+	}
+
+	return true
+}
+
+// WaitForReadyPods blocks until pods with matching label selectors are ready.
+// It accepts a context, allowing a timeout or deadline to be specified. When
+// all pods are ready, it returns a slice of strings with their IP addresses.
+// The order will match the label selectors.
+//
+// The syntax for the selectors is defined in the Parse function documented at
+// pkg.go.dev/k8s.io/apimachinery/pkg/labels.
+//
+// If the timeout is exceeded or there is a problem communicating with the
+// Kubernetes API, an error is returned.
+func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]string, error) {
+	timeoutsEnabled := true
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		timeoutsEnabled = false
+		log.Printf("no timeout is set; this could block forever")
+	}
+
+	selectors, err := parseSelectors(args)
+	if err != nil {
+		return nil, err
+	}
+
+	var podIPs []string
+	for range selectors {
+		podIPs = append(podIPs, "")
+	}
+
+	matchCount := 0
+
+	for {
+		if timeoutsEnabled && time.Now().After(deadline) {
+			return nil, errors.New("timeout exceeded")
+		}
+
+		podList, err := pl.List(metav1.ListOptions{})
+		if err != nil {
+			log.Fatalf("failed to fetch list of pods: %v", err)
+		}
+
+		for _, pod := range podList.Items {
+			if !isPodReady(&pod) {
+				continue
+			}
+
+			for i, selector := range selectors {
+				if podIPs[i] != "" {
+					continue
+				}
+
+				if selector.Matches(labels.Set(pod.Labels)) {
+					podIPs[i] = pod.Status.PodIP
+					matchCount++
+					break
+				}
+			}
+		}
+
+		if matchCount == len(selectors) {
+			break
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	return podIPs, nil
+}
+
+func main() {
+	var err error
+	timeout := DefaultTimeout
+	timeoutStr, ok := os.LookupEnv(TimeoutEnv)
+	if ok {
+		timeout, err = time.ParseDuration(timeoutStr)
+		if err != nil {
+			log.Fatalf("failed to parse $%s: %v", TimeoutEnv, err)
+		}
+	}
+
+	var clientset kubernetes.Interface
+	kubeConfigFile, ok := os.LookupEnv(KubeConfigEnv)
+	if ok {
+		clientset, err = kubehelpers.ConnectWithConfig(kubeConfigFile)
+		if err != nil {
+			log.Fatalf("failed to read kubeconfig: %v", err)
+		}
+	} else {
+		clientset, err = kubehelpers.ConnectWithinCluster()
+		if err != nil {
+			log.Fatalf("failed to connect with implicit kubeconfig: %v", err)
+		}
+	}
+
+	outputFile := DefaultOutputFile
+	outputFileOverride, ok := os.LookupEnv(OutputFileEnv)
+	if ok {
+		outputFile = outputFileOverride
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	podIPs, err := WaitForReadyPods(ctx, clientset.CoreV1().Pods(metav1.NamespaceAll), os.Args[1:])
+	if err != nil {
+		log.Fatalf("failed to wait for ready pods: %v", err)
+	}
+
+	log.Printf("all pods ready, exiting successfully")
+	workerFileBody := strings.Join(podIPs, ",")
+	ioutil.WriteFile(outputFile, []byte(workerFileBody), 0777)
+}

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -133,6 +133,7 @@ func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]strin
 	}
 
 	matchCount := 0
+	matchingPods := make(map[string]bool)
 
 	for {
 		if timeoutsEnabled && time.Now().After(deadline) {
@@ -149,6 +150,10 @@ func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]strin
 				continue
 			}
 
+			if _, alreadyMatched := matchingPods[pod.Name]; alreadyMatched {
+				continue
+			}
+
 			for i, selector := range selectors {
 				if podIPs[i] != "" {
 					continue
@@ -156,6 +161,7 @@ func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]strin
 
 				if selector.Matches(labels.Set(pod.Labels)) {
 					podIPs[i] = pod.Status.PodIP
+					matchingPods[pod.Name] = true
 					matchCount++
 					break
 				}

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -111,7 +111,7 @@ func isPodReady(pod *corev1.Pod) bool {
 }
 
 // findDriverPort searches through a pod's list of containers and their ports to
-// locate a port named "driver". If discovered, it's number is returned. If not
+// locate a port named "driver". If discovered, its number is returned. If not
 // found, DefaultDriverPort is returned.
 func findDriverPort(pod *corev1.Pod) int32 {
 	for _, container := range pod.Spec.Containers {
@@ -135,7 +135,7 @@ func findDriverPort(pod *corev1.Pod) int32 {
 //
 // The driver port is determined by searching the pod for a container with a TCP
 // port named "driver". If there is no port named "driver" exposed on any of the
-// matching pod's containers, the value of defaults.DriverPort will be used.
+// matching pod's containers, the value of DefaultDriverPort will be used.
 //
 // If the timeout is exceeded or there is a problem communicating with the
 // Kubernetes API, an error is returned.

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -72,10 +72,10 @@ type PodLister interface {
 
 // parseSelectors accepts a slice of strings and converts them into Kubernetes
 // selectors. It returns an error if any of the strings is not a valid selector.
-func parseSelectors(args []string) ([]labels.Selector, error) {
+func parseSelectors(sels []string) ([]labels.Selector, error) {
 	var selectors []labels.Selector
 
-	for i, arg := range args {
+	for i, arg := range sels {
 		selector, err := labels.Parse(arg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse selector #%d (%s): %v", i+1, arg, err)
@@ -139,7 +139,7 @@ func findDriverPort(pod *corev1.Pod) int32 {
 //
 // If the timeout is exceeded or there is a problem communicating with the
 // Kubernetes API, an error is returned.
-func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]string, error) {
+func WaitForReadyPods(ctx context.Context, pl PodLister, sels []string) ([]string, error) {
 	timeoutsEnabled := true
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -147,7 +147,7 @@ func WaitForReadyPods(ctx context.Context, pl PodLister, args []string) ([]strin
 		log.Printf("no timeout is set; this could block forever")
 	}
 
-	selectors, err := parseSelectors(args)
+	selectors, err := parseSelectors(sels)
 	if err != nil {
 		return nil, err
 	}

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WaitForReadyPods", func() {
+	var fastDuration time.Duration
+	var slowDuration time.Duration
+
+	var irrelevantPod corev1.Pod
+	var driverPod corev1.Pod
+	var serverPod corev1.Pod
+	var clientPod corev1.Pod
+
+	BeforeEach(func() {
+		fastDuration = 1 * time.Millisecond * timeMultiplier
+		slowDuration = 1000 * time.Millisecond * timeMultiplier
+
+		irrelevantPod = corev1.Pod{}
+
+		driverPod = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"role": "driver",
+				},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "127.0.0.1",
+			},
+		}
+
+		serverPod = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"role": "server",
+				},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "127.0.0.2",
+			},
+		}
+
+		clientPod = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"role": "client",
+				},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "127.0.0.3",
+			},
+		}
+
+	})
+
+	It("returns successfully without args", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mock := &PodListerMock{
+			PodList: &corev1.PodList{},
+		}
+
+		podIPs, err := WaitForReadyPods(ctx, mock, []string{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(podIPs).To(BeEmpty())
+	})
+
+	It("timeout reached when no matching pods are found", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
+		defer cancel()
+
+		mock := &PodListerMock{
+			PodList: &corev1.PodList{
+				Items: []corev1.Pod{irrelevantPod},
+			},
+		}
+
+		_, err := WaitForReadyPods(ctx, mock, []string{"hello-anyone-out-there"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("timeout reached when only some matching pods are found", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
+		defer cancel()
+
+		mock := &PodListerMock{
+			PodList: &corev1.PodList{
+				Items: []corev1.Pod{
+					driverPod,
+					clientPod,
+					// note: missing 2nd client
+				},
+			},
+		}
+
+		_, err := WaitForReadyPods(ctx, mock, []string{"role=driver", "role=client", "role=client"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("timeout reached when pod does not match all labels", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
+		defer cancel()
+
+		mock := &PodListerMock{
+			PodList: &corev1.PodList{
+				Items: []corev1.Pod{driverPod},
+			},
+		}
+
+		_, err := WaitForReadyPods(ctx, mock, []string{"role=driver,loadtest=loadtest-1"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns successfully when all matching pods are found", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
+		defer cancel()
+
+		mock := &PodListerMock{
+			PodList: &corev1.PodList{
+				Items: []corev1.Pod{
+					driverPod,
+					serverPod,
+					clientPod,
+					clientPod,
+				},
+			},
+		}
+
+		podIPs, err := WaitForReadyPods(ctx, mock, []string{
+			"role=driver",
+			"role=server",
+			"role=client",
+			"role=client",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(podIPs).To(Equal([]string{
+			driverPod.Status.PodIP,
+			serverPod.Status.PodIP,
+			clientPod.Status.PodIP,
+			clientPod.Status.PodIP,
+		}))
+	})
+
+	It("returns error if timeout exceeded", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), fastDuration)
+		defer cancel()
+
+		mock := &PodListerMock{
+			SleepDuration: slowDuration,
+			PodList:       &corev1.PodList{},
+		}
+
+		_, err := WaitForReadyPods(ctx, mock, []string{"example"})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+type PodListerMock struct {
+	PodList       *corev1.PodList
+	SleepDuration time.Duration
+	Error         error
+	invocation    int
+}
+
+func (plm *PodListerMock) List(opts metav1.ListOptions) (*corev1.PodList, error) {
+	time.Sleep(plm.SleepDuration)
+
+	if plm.Error != nil {
+		return nil, plm.Error
+	}
+
+	return plm.PodList, nil
+}

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -148,11 +148,12 @@ var _ = Describe("WaitForReadyPods", func() {
 	})
 
 	It("returns successfully when all matching pods are found", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
 		defer cancel()
 
-		client2Pod := clientPod
+		client2Pod := newTestPod("client")
 		client2Pod.Name = "client-2"
+		client2Pod.Status.PodIP = "127.0.0.4"
 
 		mock := &PodListerMock{
 			PodList: &corev1.PodList{
@@ -176,7 +177,7 @@ var _ = Describe("WaitForReadyPods", func() {
 			fmt.Sprintf("%s:%d", driverPod.Status.PodIP, DefaultDriverPort),
 			fmt.Sprintf("%s:%d", serverPod.Status.PodIP, DefaultDriverPort),
 			fmt.Sprintf("%s:%d", clientPod.Status.PodIP, DefaultDriverPort),
-			fmt.Sprintf("%s:%d", clientPod.Status.PodIP, DefaultDriverPort),
+			fmt.Sprintf("%s:%d", client2Pod.Status.PodIP, DefaultDriverPort),
 		}))
 	})
 

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -76,7 +76,7 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{"hello-anyone-out-there"})
+		_, err := WaitForReadyPods(ctx, mock, []string{"hello=anyone-out-there"})
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-
 var _ = Describe("WaitForReadyPods", func() {
 	var fastDuration time.Duration
 	var slowDuration time.Duration
@@ -239,37 +238,4 @@ func (plm *PodListerMock) List(opts metav1.ListOptions) (*corev1.PodList, error)
 	}
 
 	return plm.PodList, nil
-}
-
-func newTestPod(role string) corev1.Pod {
-	return corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: role,
-			Labels: map[string]string{
-				"role": role,
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "run",
-					Ports: []corev1.ContainerPort{
-						{
-							Name: "driver",
-							Protocol: corev1.ProtocolTCP,
-							ContainerPort: DefaultDriverPort,
-						},
-					},
-				},
-			},
-		},
-		Status: corev1.PodStatus{
-			PodIP: "127.0.0.1",
-			ContainerStatuses: []corev1.ContainerStatus{
-				{
-					Ready: true,
-				},
-			},
-		},
-	}
 }

--- a/containers/init/ready/suite_test.go
+++ b/containers/init/ready/suite_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// timeMultiplier provides a way to increase or decrease the timeouts for each
+// test.
+const timeMultiplier = 1
+
+func TestReady(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ready Suite")
+}

--- a/containers/init/ready/suite_test.go
+++ b/containers/init/ready/suite_test.go
@@ -31,3 +31,36 @@ func TestReady(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Ready Suite")
 }
+
+func newTestPod(role string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: role,
+			Labels: map[string]string{
+				"role": role,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "run",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "driver",
+							Protocol:      corev1.ProtocolTCP,
+							ContainerPort: DefaultDriverPort,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "127.0.0.1",
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+		},
+	}
+}

--- a/containers/init/ready/suite_test.go
+++ b/containers/init/ready/suite_test.go
@@ -21,6 +21,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // timeMultiplier provides a way to increase or decrease the timeouts for each

--- a/internal/kubehelpers/auth.go
+++ b/internal/kubehelpers/auth.go
@@ -1,0 +1,58 @@
+// Copyright 2020 gRPC authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubehelpers contains Kubernetes helper functions.
+package kubehelpers
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	// This side-effect import is required by GKE.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ConnectWithinCluster uses Kubernetes utility functions to locate
+// the credentials within the cluster and connect to the API.
+func ConnectWithinCluster() (*kubernetes.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+// ConnectWithConfig takes an absolute path to a kube config file
+// which is used to connect to the Kubernetes API.
+func ConnectWithConfig(abspath string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", abspath)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}


### PR DESCRIPTION
The driver needs to wait for all worker pods to be assigned an IP address and be ready before running. This change introduces the ready init container. This container allows the driver to block until a pods with matching labels become ready or a timeout is reached.