### PR TITLE
Set default namespace on load tests and their pods

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -404,7 +404,8 @@ func newPod(loadtest *grpcv1.LoadTest, component *grpcv1.Component, role string)
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s-%s", loadtest.Name, role, *component.Name),
+			Name:      fmt.Sprintf("%s-%s-%s", loadtest.Name, role, *component.Name),
+			Namespace: loadtest.Namespace,
 			Labels: map[string]string{
 				defaults.LoadTestLabel:      loadtest.Name,
 				defaults.RoleLabel:          role,

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -32,6 +32,15 @@ var _ = Describe("Pod Creation", func() {
 			component = &loadtest.Spec.Clients[0].Component
 		})
 
+		It("sets namespace to match loadtest", func() {
+			namespace := "foobar"
+			loadtest.Namespace = namespace
+
+			pod, err := newClientPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Namespace).To(Equal(namespace))
+		})
+
 		It("sets component-name label", func() {
 			name := "foo-bar-buzz"
 			component.Name = &name
@@ -125,6 +134,15 @@ var _ = Describe("Pod Creation", func() {
 
 		BeforeEach(func() {
 			component = &loadtest.Spec.Driver.Component
+		})
+
+		It("sets namespace to match loadtest", func() {
+			namespace := "foobar"
+			loadtest.Namespace = namespace
+
+			pod, err := newDriverPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Namespace).To(Equal(namespace))
 		})
 
 		It("adds a scenario volume", func() {
@@ -263,6 +281,15 @@ var _ = Describe("Pod Creation", func() {
 
 		BeforeEach(func() {
 			component = &loadtest.Spec.Servers[0].Component
+		})
+
+		It("sets namespace to match loadtest", func() {
+			namespace := "foobar"
+			loadtest.Namespace = namespace
+
+			pod, err := newServerPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Namespace).To(Equal(namespace))
 		})
 
 		It("sets loadtest-role label to server", func() {

--- a/pkg/defaults/loadtest_defaults.go
+++ b/pkg/defaults/loadtest_defaults.go
@@ -4,6 +4,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	corev1 "k8s.io/api/core/v1"
+
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 )
 
@@ -17,6 +19,10 @@ func CopyWithDefaults(d *Defaults, loadtest *grpcv1.LoadTest) (*grpcv1.LoadTest,
 	im := newImageMap(d.Languages)
 	test := loadtest.DeepCopy()
 	spec := &test.Spec
+
+	if test.Namespace == "" {
+		test.Namespace = corev1.NamespaceDefault
+	}
 
 	if spec.Driver == nil {
 		spec.Driver = &grpcv1.Driver{

--- a/pkg/defaults/loadtest_defaults_test.go
+++ b/pkg/defaults/loadtest_defaults_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
@@ -75,6 +76,12 @@ var _ = Describe("CopyWithDefaults", func() {
 			loadtest.Spec.Driver.Name = nil
 			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
 			Expect(copy.Spec.Driver.Name).ToNot(BeNil())
+		})
+
+		It("sets default namespace when unspecified", func() {
+			loadtest.Namespace = ""
+			copy, _ := CopyWithDefaults(defaultOptions, loadtest)
+			Expect(copy.Namespace).To(Equal(corev1.NamespaceDefault))
 		})
 
 		It("sets default when nil", func() {


### PR DESCRIPTION
The previous version of the code did not specify a namespace when creating pods for load tests. This led to a panic, because the default namespace is not inferred.

This change explicitly sets the namespace of pods to match the namespace of the load test. Though unlikely to be required, it also ensures that the load test lives in the default namespace if another has not been specified.