### PR TITLE
Fix wrong tag name in defaults

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -47,7 +47,7 @@ type LanguageDefault struct {
 	// Language uniquely identifies a programming language. When the
 	// system encounters this name, it will select the build image and
 	// run image as the defaults.
-	Language string `json:"name"`
+	Language string `json:"language"`
 
 	// BuildImage specifies the default container image for building or
 	// assembling an executable or bundle for a language. This image


### PR DESCRIPTION
The LanguageDefault type in the defaults package used to have a `Name` field. This represented the name of the programming language and was renamed to `Language`. During the rename, the JSON tag was not changed. This commit updates the JSON tag.