### PR TITLE
Fix iterator reference issue in defaults package

### DIFF
--- a/pkg/defaults/defaults_internal.go
+++ b/pkg/defaults/defaults_internal.go
@@ -31,8 +31,9 @@ type imageMap struct {
 func newImageMap(lds []LanguageDefault) *imageMap {
 	m := make(map[string]*LanguageDefault)
 
-	for _, ld := range lds {
-		m[ld.Language] = &ld
+	for i := range lds {
+		ld := &lds[i]
+		m[ld.Language] = ld
 	}
 
 	return &imageMap{m}


### PR DESCRIPTION
The defaults package contains an internal type called imageMap. This type is used to efficiently lookup default images for a language. During the creation of its internal map, the code relied on the address of an iterator. This led to the map being populated with only the last value. This change fixes this issue.

Special thanks to @wanlin31 for noticing this issue.