### PR TITLE
Fix issues and simplify example load test YAML file

### DIFF
--- a/config/samples/e2etest.grpc.io_v1_loadtest.yaml
+++ b/config/samples/e2etest.grpc.io_v1_loadtest.yaml
@@ -78,7 +78,7 @@ spec:
             repo: https://github.com/grpc/grpc-java.git
             gitRef: master
           build:
-            command: ["./gradlew"]
+            command: ["gradle"]
             args: ["--no-daemon", "-PskipCodegen=true", "-PskipAndroid=true", ":grpc-benchmarks:installDist"]
           run:
             command: ["/src/workspace/benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker"]
@@ -99,11 +99,10 @@ spec:
           repo: https://github.com/grpc/grpc-java.git
           gitRef: master
         build:
-          command: ["./gradlew"]
+          command: ["gradle"]
           args: ["--no-daemon", "-PskipCodegen=true", "-PskipAndroid=true", ":grpc-benchmarks:installDist"]
         run:
           command: ["/src/workspace/benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker"]
-          args: []
 
     # We can optionally specify where to place the results. The
     # controller will attempt to mount a service account in the driver.
@@ -121,5 +120,5 @@ spec:
     # Kubernetes objects themselves. If we did want to couple, they
     # could also be inlined.
     scenarios:
-        - name: java-example-generic-async-streaming-ping-pong-secure
+        - name: java-example-scenario
 

--- a/config/samples/e2etest.grpc.io_v1_loadtest.yaml
+++ b/config/samples/e2etest.grpc.io_v1_loadtest.yaml
@@ -13,53 +13,6 @@ metadata:
     labels:
         language: java
 spec:
-    # The driver is required by all tests and should not change often.
-    # For this reason, it can be omitted from the spec. The controller
-    # will then use the driver from grpc/grpc at master.
-    driver:
-        language: cxx
-        clone:
-            # Clone is an init container that knows how to obtain a
-            # specific snapshot of code and place it in the
-            # /src/workspace path. When no "image" is specified, the
-            # controller uses a default that can clone public GitHub
-            # repositories.
-            #
-            # A user can circumvent the requirement for GitHub by
-            # using a custom image here. Any image which places code in
-            # a /src/workspace directory is compatible with the system.
-            repo: https://github.com/grpc/grpc.git
-            gitRef: master
-        build:
-            # Build is an init container that contains a compiler
-            # to build code in /src/workspace. Any image that compiles
-            # code, placing an executable in /src/workspace is
-            # compatible.
-            #
-            # In this case, image is inferred to be the latest "bazel"
-            # image, since it is omitted and the language is c++.
-            #
-            # The bazel image requires an output_user_root flag. To
-            # resist magical behavior, we require its inclusion in
-            # the listed args. I plan to open a ticket with the Bazel
-            # team to see if we can extract this into an env variable.
-            command: ["bazel"]
-            args: ["build","//test/cpp/qps:qps_json_driver", "--output_user_root=/src/workspace"]
-        run:
-            # Run describes the runtime of the test. The image is
-            # inferred to be the latest c++ runtime image, since it
-            # is omitted and the language is set to c++. A user can
-            # specify any runtime image, however.
-            #
-            # By design, the built executable and code is available
-            # over a shared volume at the /src/workspace path.
-            command: ["/src/workspace/bazel-bin/test/cpp/qps/qps_json_driver"]
-            # The controller is smart regarding a driver, passing the
-            # appropriate arguments to configure the scenario. The
-            # user does not need to specify any. If they do, their
-            # arguments will override the defaults.
-            args: []
-
     # The user can specify servers to use when running tests. The
     # initial version only supports 1 server to limit scope. Servers
     # is an array for future expansion.
@@ -69,11 +22,6 @@ spec:
     # will likely be expanded in the future.
     servers:
         - language: java
-          # Any driver, server or client component can specify a node
-          # pool. This permits testing with many architectures. When
-          # omitted (as with the driver and client), the system will
-          # choose defaults.
-          pool: workers-32core
           clone:
             repo: https://github.com/grpc/grpc-java.git
             gitRef: master
@@ -82,14 +30,6 @@ spec:
             args: ["--no-daemon", "-PskipCodegen=true", "-PskipAndroid=true", ":grpc-benchmarks:installDist"]
           run:
             command: ["/src/workspace/benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker"]
-            # The controller is smart regarding ports. If args
-            # are omitted, the system will pass appropriate args
-            # to assign ports and permit driver communication.
-            #
-            # In the future, I would like to move ports out of
-            # args and into env variables. This would make the
-            # system feel less fragile.
-            args: []
 
     # Users can specify multiple clients. They are bound by the
     # number of nodes.


### PR DESCRIPTION
The example YAML file references a gradle file in the repository. It should reference the gradle executable in the container. In addition, it specifies the wrong name for the example scenario. This change fixes these issues by using the built-in executable and correcting the incorrectly named scenario.