### PR TITLE
Set build and run working directory to workspace

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -434,11 +434,12 @@ func newBuildContainer(build *grpcv1.Build) corev1.Container {
 	}
 
 	return corev1.Container{
-		Name:    buildInitContainer,
-		Image:   *build.Image,
-		Command: build.Command,
-		Args:    build.Args,
-		Env:     build.Env,
+		Name:       buildInitContainer,
+		Image:      *build.Image,
+		Command:    build.Command,
+		Args:       build.Args,
+		Env:        build.Env,
+		WorkingDir: workspaceMountPath,
 		VolumeMounts: []corev1.VolumeMount{
 			newWorkspaceVolumeMount(),
 		},
@@ -448,11 +449,12 @@ func newBuildContainer(build *grpcv1.Build) corev1.Container {
 // newRunContainer constructs a container given a grpcv1.Run object.
 func newRunContainer(run grpcv1.Run) corev1.Container {
 	return corev1.Container{
-		Name:    runContainer,
-		Image:   *run.Image,
-		Command: run.Command,
-		Args:    run.Args,
-		Env:     run.Env,
+		Name:       runContainer,
+		Image:      *run.Image,
+		Command:    run.Command,
+		Args:       run.Args,
+		Env:        run.Env,
+		WorkingDir: workspaceMountPath,
 		VolumeMounts: []corev1.VolumeMount{
 			newWorkspaceVolumeMount(),
 		},

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -500,6 +500,11 @@ var _ = Describe("Pod Creation", func() {
 			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
 		})
 
+		It("sets workspace as working directory", func() {
+			container := newBuildContainer(build)
+			Expect(container.WorkingDir).To(Equal(workspaceMountPath))
+		})
+
 		It("returns empty container given nil pointer", func() {
 			build = nil
 			container := newBuildContainer(build)
@@ -567,6 +572,11 @@ var _ = Describe("Pod Creation", func() {
 			container := newRunContainer(run)
 			volumeMount := newWorkspaceVolumeMount()
 			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
+		})
+
+		It("sets workspace as working directory", func() {
+			container := newRunContainer(run)
+			Expect(container.WorkingDir).To(Equal(workspaceMountPath))
 		})
 
 		It("sets image", func() {

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -127,6 +127,14 @@ var _ = Describe("Pod Creation", func() {
 			Expect(err).To(BeNil())
 			Expect(pod.Spec.Containers[0].Ports).To(ContainElement(port))
 		})
+
+		It("sets workspace volume", func() {
+			pod, err := newClientPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newWorkspaceVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
 	})
 
 	Describe("newDriverPod", func() {
@@ -274,6 +282,14 @@ var _ = Describe("Pod Creation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		})
+
+		It("sets workspace volume", func() {
+			pod, err := newDriverPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newWorkspaceVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
 	})
 
 	Describe("newServerPod", func() {
@@ -386,6 +402,14 @@ var _ = Describe("Pod Creation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		})
+
+		It("sets workspace volume", func() {
+			pod, err := newServerPod(loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newWorkspaceVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
 	})
 
 	Describe("newCloneContainer", func() {
@@ -406,6 +430,12 @@ var _ = Describe("Pod Creation", func() {
 		It("sets the name of the container", func() {
 			container := newCloneContainer(clone)
 			Expect(container.Name).To(Equal(cloneInitContainer))
+		})
+
+		It("sets workspace volume mount", func() {
+			container := newCloneContainer(clone)
+			volumeMount := newWorkspaceVolumeMount()
+			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
 		})
 
 		It("returns empty container given nil pointer", func() {
@@ -462,6 +492,12 @@ var _ = Describe("Pod Creation", func() {
 		It("sets the name of the container", func() {
 			container := newBuildContainer(build)
 			Expect(container.Name).To(Equal(buildInitContainer))
+		})
+
+		It("sets workspace volume mount", func() {
+			container := newBuildContainer(build)
+			volumeMount := newWorkspaceVolumeMount()
+			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
 		})
 
 		It("returns empty container given nil pointer", func() {
@@ -527,6 +563,12 @@ var _ = Describe("Pod Creation", func() {
 			Expect(container.Name).To(Equal(runContainer))
 		})
 
+		It("sets workspace volume mount", func() {
+			container := newRunContainer(run)
+			volumeMount := newWorkspaceVolumeMount()
+			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
+		})
+
 		It("sets image", func() {
 			image := "golang:1.14"
 			run.Image = &image
@@ -564,6 +606,13 @@ var _ = Describe("Pod Creation", func() {
 			container := newRunContainer(run)
 			Expect(env[0]).To(BeElementOf(container.Env))
 			Expect(env[1]).To(BeElementOf(container.Env))
+		})
+	})
+
+	Describe("newWorkspaceVolumeMount", func() {
+		It("grants read and write access", func() {
+			volumeMount := newWorkspaceVolumeMount()
+			Expect(volumeMount.ReadOnly).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
This commit sets the working directory for the build init container and run container to the /src/workspace volume mount.

This does not set the working directory on the init container, because it does not require a specific working directory.