### PR TITLE
Add worker address file parsing to driver

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -78,6 +78,7 @@ COPY . .
 RUN chmod a+x run.sh
 
 ENV QPS_WORKERS=""
+ENV QPS_WORKERS_FILE=""
 ENV SCENARIOS_FILE="example.json"
 ENV BQ_RESULT_TABLE=""
 

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -15,6 +15,10 @@
 
 set -ex
 
+if [ -n "$QPS_WORKERS_FILE" ]; then
+  export QPS_WORKERS=$(cat $QPS_WORKERS_FILE)
+fi
+
 bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
   --scenario_result_file='scenario_result.json'
 


### PR DESCRIPTION
The driver needs a comma-delimited list of IP addresses and port numbers for workers. It receives this list from the `$QPS_WORKERS` environment variable.

This change makes it possible to set a `$QPS_WORKERS_FILE` environment variable on the driver. When present, the driver container copies the contents of the file into the `$QPS_WORKERS` environment variable before invoking the driver executable. This allows the driver to learn these addresses through a shared volume.

Tested and confirmed to work as expected. Pushed to GCR.