### PR TITLE
Fix issue with overridden workspace in the driver 

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -19,24 +19,28 @@ ARG GITREF=master
 
 RUN apt-get update && apt-get install -y git
 
-RUN mkdir -p /grpc/grpc
-WORKDIR /grpc/grpc
+RUN mkdir -p /src/code
+WORKDIR /src/code
 
 RUN git clone https://github.com/$REPOSITORY.git .
 RUN git submodule update --init
 
 FROM l.gcr.io/google/bazel:0.17.1
 
-COPY --from=0 /grpc/grpc /src/workspace
+COPY --from=0 /src/code /src/code
 RUN mkdir -p /tmp/build_output
-WORKDIR /src/workspace
+WORKDIR /src/code
 RUN bazel --output_user_root=/tmp/build_output build //test/cpp/qps:qps_json_driver
 
 FROM debian:buster
 
-WORKDIR /grpc/grpc
+RUN mkdir -p /src/driver
+RUN mkdir -p /src/code
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
 COPY --from=1 /tmp/build_output /tmp/build_output
-COPY --from=1 /src/workspace .
+COPY --from=1 /src/code /src/code
 
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -74,12 +78,12 @@ RUN pip3 install \
   pyasn1_modules==0.2.2 \
   pyasn1==0.4.2
 
-COPY . .
-RUN chmod a+x run.sh
+COPY . /src/driver
+RUN chmod a+x /src/driver/run.sh
 
 ENV QPS_WORKERS=""
 ENV QPS_WORKERS_FILE=""
-ENV SCENARIOS_FILE="example.json"
+ENV SCENARIOS_FILE="/src/driver/example.json"
 ENV BQ_RESULT_TABLE=""
 
-CMD ["./run.sh"]
+CMD ["/src/driver/run.sh"]

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -78,6 +78,7 @@ COPY . .
 RUN chmod a+x run.sh
 
 ENV QPS_WORKERS=""
+ENV QPS_WORKERS_FILE=""
 ENV SCENARIOS_FILE="example.json"
 ENV BQ_RESULT_TABLE=""
 

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -15,6 +15,10 @@
 
 set -ex
 
+if [ -n "$QPS_WORKERS_FILE" ]; then
+  export QPS_WORKERS=$(cat $QPS_WORKERS_FILE)
+fi
+
 bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
   --scenario_result_file='scenario_result.json'
 

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -19,11 +19,11 @@ if [ -n "$QPS_WORKERS_FILE" ]; then
   export QPS_WORKERS=$(cat $QPS_WORKERS_FILE)
 fi
 
-bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
+/src/code/bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
   --scenario_result_file='scenario_result.json'
 
 if [ "$BQ_RESULT_TABLE" != "" ]
 then
-  python3 tools/run_tests/performance/bq_upload_result.py --bq_result_table="$BQ_RESULT_TABLE"
+  python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="$BQ_RESULT_TABLE"
 fi
 


### PR DESCRIPTION
The clone, build and run pipeline shares files in the /src/workspace directory over a volume. The driver includes the code and executable in the image. However, the volume is always mounted and initially an empty directory. This caused all files to be deleted before the driver runs.

This change places the included code and executable in a path separate from the /src/workspace mount. This will allow the driver to work out of the box or from a version cloned and built at runtime.

Merge #40 first, since this depends on it.