### PR TITLE
Switch example load test to use Go

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -1,15 +1,15 @@
 # Examples
 
-This directory contains a [LoadTest](e2etest.grpc.io_v1_loadtest.yaml) and an
-example [scenario](java_example_scenario.json) for Java.
+This directory contains a [LoadTest](e2etest.grpc.io_v1_loadtest.yaml) and some
+example scenarios.
 
-The LoadTest references a ConfigMap named *java-example-scenario*, which should
+The LoadTest references a ConfigMap named *go-example-scenario*, which should
 contain the contents of the scenario protobuf as JSON. Once you have
 authenticated with a Kubernetes cluster, this command will create it:
 
 ```
-$ kubectl create configmap java-example-scenario \
-    --from-file=java_example_scenario.json
+$ kubectl create configmap go-example-scenario \
+    --from-file=go_example_scenario.json
 ```
 
 Every ConfigMap must have a unique name. You will need to choose a different
@@ -31,5 +31,5 @@ grpc/test-infra's api/v1 directory:
 After testing, you can delete the ConfigMap using:
 
 ```
-$ kubectl delete configmap java-example-scenario
+$ kubectl delete configmap go-example-scenario
 ```

--- a/config/samples/e2etest.grpc.io_v1_loadtest.yaml
+++ b/config/samples/e2etest.grpc.io_v1_loadtest.yaml
@@ -4,14 +4,14 @@ metadata:
     # Every load test instance must be assigned a unique name on the
     # cluster. There are ways we can circumvent naming clashes, such
     # as using namespaces or dynamically assigning names.
-    name: java-example
+    name: go-example
 
     # As a custom resource, it behaves like a native kubernetes object.
     # This means that users can perform CRUD operations through the
     # Kubernetes API or kubectl. In addition, it means that the user
     # can set any metadata on it.
     labels:
-        language: java
+        language: go
 spec:
     # The user can specify servers to use when running tests. The
     # initial version only supports 1 server to limit scope. Servers
@@ -21,28 +21,28 @@ spec:
     # organizing and monitoring a mesh of servers. Therefore, this
     # will likely be expanded in the future.
     servers:
-        - language: java
+        - language: go
           clone:
-            repo: https://github.com/grpc/grpc-java.git
+            repo: https://github.com/grpc/grpc-go.git
             gitRef: master
           build:
-            command: ["gradle"]
-            args: ["--no-daemon", "-PskipCodegen=true", "-PskipAndroid=true", ":grpc-benchmarks:installDist"]
+            command: ["go"]
+            args: ["build", "-o", "/src/workspace/bin/worker", "./benchmark/worker"]
           run:
-            command: ["/src/workspace/benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker"]
+            command: ["/src/workspace/bin/worker"]
 
     # Users can specify multiple clients. They are bound by the
     # number of nodes.
     clients:
-      - language: java
-        clone:
-          repo: https://github.com/grpc/grpc-java.git
-          gitRef: master
-        build:
-          command: ["gradle"]
-          args: ["--no-daemon", "-PskipCodegen=true", "-PskipAndroid=true", ":grpc-benchmarks:installDist"]
-        run:
-          command: ["/src/workspace/benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker"]
+        - language: go
+          clone:
+            repo: https://github.com/grpc/grpc-go.git
+            gitRef: master
+          build:
+            command: ["go"]
+            args: ["build", "-o", "/src/workspace/bin/worker", "./benchmark/worker"]
+          run:
+            command: ["/src/workspace/bin/worker"]
 
     # We can optionally specify where to place the results. The
     # controller will attempt to mount a service account in the driver.
@@ -60,5 +60,5 @@ spec:
     # Kubernetes objects themselves. If we did want to couple, they
     # could also be inlined.
     scenarios:
-        - name: java-example-scenario
+        - name: go-example-scenario
 

--- a/config/samples/go_example_scenario.json
+++ b/config/samples/go_example_scenario.json
@@ -1,0 +1,59 @@
+{
+  "scenarios": [
+    {
+      "name": "go_example_scenario",
+      "warmup_seconds": 5,
+      "benchmark_seconds": 30,
+      "num_servers": 1,
+      "server_config": {
+        "async_server_threads": 1,
+        "channel_args": [
+          {
+            "str_value": "latency",
+            "name": "grpc.optimization_target"
+          }
+        ],
+        "server_type": "ASYNC_GENERIC_SERVER",
+        "payload_config": {
+          "bytebuf_params": {
+            "resp_size": 0,
+            "req_size": 0
+          }
+        },
+        "security_params": null,
+        "threads_per_cq": 0,
+        "server_processes": 0
+      },
+      "client_config": {
+        "security_params": null,
+        "channel_args": [
+          {
+            "str_value": "latency",
+            "name": "grpc.optimization_target"
+          }
+        ],
+        "async_client_threads": 1,
+        "outstanding_rpcs_per_channel": 1,
+        "rpc_type": "STREAMING",
+        "payload_config": {
+          "bytebuf_params": {
+            "resp_size": 0,
+            "req_size": 0
+          }
+        },
+        "client_channels": 1,
+        "threads_per_cq": 0,
+        "load_params": {
+          "closed_loop": {}
+        },
+        "client_type": "SYNC_CLIENT",
+        "histogram_params": {
+          "max_possible": 60000000000,
+          "resolution": 0.01
+        },
+        "client_processes": 0
+      },
+      "num_clients": 1
+    }
+  ]
+}


### PR DESCRIPTION
The Go load tests build and start much quicker and they are easier to read. For this reason, this pull request switches the example load test to use Go workers. In addition, it adds an example Go scenario and updates the README.md file to reflect these changes. 