### PR TITLE
Use less commonly used ports as defaults

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -75,7 +75,11 @@ var _ = BeforeSuite(func(done Done) {
 	err = grpcv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: ":3777",
+		Port:               9443,
+	})
 	Expect(err).ToNot(HaveOccurred())
 
 	reconciler := &LoadTestReconciler{

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&defaultsFile, "defaults-file", "", "The path to a YAML file with a default configuration")
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":3777", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
The default ports used by kubebuilder are commonly used by other services. For example, port :8080 is used by many web applications. This change switches to ports that are less commonly used.