### PR TITLE
Fix incorrect plurality for scenarios env variable

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -52,9 +52,9 @@ const runContainer = "run"
 // mounted in the driver container.
 const scenarioMountPath = "/src/scenarios"
 
-// scenarioFileEnv specifies the name of an env variable that specifies the path
-// to a JSON file with a scenario.
-const scenarioFileEnv = "SCENARIO_FILE"
+// scenariosFileEnv specifies the name of an env variable that specifies the
+// path to a JSON file with scenarios.
+const scenariosFileEnv = "SCENARIOS_FILE"
 
 // CloneRepoEnv specifies the name of the env variable that contains the git
 // repository to clone.
@@ -331,7 +331,7 @@ func newWorkspaceVolumeMount() corev1.VolumeMount {
 func newScenarioFileEnvVar(scenario string) corev1.EnvVar {
 	scenarioFile := strings.ReplaceAll(scenario, "-", "_") + ".json"
 	return corev1.EnvVar{
-		Name:  scenarioFileEnv,
+		Name:  scenariosFileEnv,
 		Value: scenarioMountPath + "/" + scenarioFile,
 	}
 }


### PR DESCRIPTION
The driver container looks for a `$SCENARIOS_FILE` environment variable which contains the path to a file with a list of scenarios to run. This was added in #22. By mistake, the controller set a singular version, $SCENARIO_FILE, which prevented the driver from finding and running scenarios. This change corrects the controller to use the plural version, `$SCENARIOS_FILE`. And, this resolves the issue.