### PR TITLE
Fix deployment issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ bin/*
 *.orig
 .idea/
 
+# Hide internal configs
+config/defaults.yaml
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,14 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+COPY . .
+RUN chmod 777 /workspace/config/defaults.yaml
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+FROM debian:buster
+WORKDIR /workspace
+COPY --from=builder /workspace .
+CMD ["/workspace/manager"]
 
-ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
+        - /workspace/manager
         args:
         - --enable-leader-election
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,3 +26,21 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - v1
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - pods/status
+  verbs:
+  - get

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -82,6 +82,8 @@ type LoadTestReconciler struct {
 
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=v1,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=v1,resources=pods/status,verbs=get
 
 // Reconcile attempts to bring the current state of the load test into agreement
 // with its declared spec. This may mean provisioning resources, doing nothing

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 	var defaultsFile string
 	var metricsAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&defaultsFile, "defaults-file", "", "The path to a YAML file with a default configuration")
+	flag.StringVar(&defaultsFile, "defaults-file", "config/defaults.yaml", "The path to a YAML file with a default configuration")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
This change fixes the issues with the Dockerfile, RBAC roles and defaults file to make deployments possible. In particular, it:

 - Switches the base image to `debian:buster` in the main Dockerfile. The distroless image had some issues with accessing the defaults file.

 - Adds CRUD permissions to pods and pod statuses for the manager, which encapsulates the controller.

 - Sets a default for the `-defaults-file` flag. This default points to the location of config/defaults.yaml. Similarly, the Dockerfile is updated to copy and adjust permissions on this file.

As a result of these changes, contributors must place a valid config file at the path config/defaults.yaml before building the docker image.

In addition, it adds the standard location for a customized config, config/defaults.yaml, to the .gitignore. This prevents developers from accidentally checking it in.

*With these changes, the controller has been deployed to the cluster.* :shipit:  