### PR TITLE
Add missing comma in api/v1/loadtest_types.go

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -27,7 +27,7 @@ import (
 // Clone defines expectations regarding which repository and snapshot the test
 // should use.
 type Clone struct {
-	// Image is the name of the container image that can clone code placing
+	// Image is the name of the container image that can clone code, placing
 	// it in a /src/workspace directory.
 	//
 	// This field is optional. When omitted, a container that can clone


### PR DESCRIPTION
In a comment within api/v1/loadtest_types.go, a comma got removed before a gerund phrase. This change adds it back.