### PR TITLE
Fix anti-affinities for load test pods

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -593,7 +593,7 @@ func newPod(loadtest *grpcv1.LoadTest, component *grpcv1.Component, role string)
 							LabelSelector: &metav1.LabelSelector{
 								MatchExpressions: []metav1.LabelSelectorRequirement{
 									{
-										Key:      "generated",
+										Key:      defaults.LoadTestLabel,
 										Operator: metav1.LabelSelectorOpExists,
 									},
 								},


### PR DESCRIPTION
Each load test pod is designed to be scheduled on a dedicated node. In other words, it should not share a node with another load test pod. Sharing may introduce noise in the metrics.

The pods were set to repel against other pods with a "generated" label set to any value. This label existed in the prototype but does not exist in this new system.

This change achieves the desired effect by setting pods to repel any other pods with a load test label set to any value.