### PR TITLE
Add isolation through namespaces

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,5 +1,7 @@
 # See ../pkg/defaults/defaults.go for documentation on each field.
 
+componentNamespace: default
+
 driverPool: drivers
 
 workerPool: workers-16core

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -113,11 +113,14 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Fetch the current state of the world.
 
-	nodes := new(corev1.NodeList)
-	if err = r.List(ctx, nodes); err != nil {
-		log.Error(err, "failed to list nodes")
-		return ctrl.Result{Requeue: true}, err
-	}
+	// Listing nodes will be required to achieve gang scheduling; however, this is
+	// not implemented at this time. Therefore, it is commented here for later:
+	//
+	//nodes := new(corev1.NodeList)
+	//if err = r.List(ctx, nodes); err != nil {
+	//	log.Error(err, "failed to list nodes")
+	//	return ctrl.Result{Requeue: true}, err
+	//}
 
 	pods := new(corev1.PodList)
 	if err = r.List(ctx, pods, client.InNamespace(req.Namespace)); err != nil {
@@ -186,7 +189,6 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// TODO: Add logic to schedule the next missing pod.
 
 	// PLACEHOLDERS!
-	_ = nodes
 	_ = pods
 	_ = loadtests
 	_ = loadtest

--- a/main.go
+++ b/main.go
@@ -51,8 +51,10 @@ func main() {
 	var defaultsFile string
 	var metricsAddr string
 	var enableLeaderElection bool
+	var namespace string
 	flag.StringVar(&defaultsFile, "defaults-file", "config/defaults.yaml", "The path to a YAML file with a default configuration")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":3777", "The address the metric endpoint binds to.")
+	flag.StringVar(&namespace, "namespace", "", "Limits resources considered to a specific namespace")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -83,6 +85,7 @@ func main() {
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "284e7070.e2etest.grpc.io",
+		Namespace:          namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -71,6 +70,10 @@ type LanguageDefault struct {
 
 // Defaults defines the default settings for the system.
 type Defaults struct {
+	// ComponentNamespace is the default namespace for load test components. Note
+	// this is not the namespace for the manager.
+	ComponentNamespace string `json:"componentNamespace"`
+
 	// DriverPool is the name of a pool where driver components should
 	// be scheduled by default.
 	DriverPool string `json:"driverPool"`
@@ -116,7 +119,7 @@ func (d *Defaults) SetLoadTestDefaults(test *grpcv1.LoadTest) error {
 	spec := &test.Spec
 
 	if test.Namespace == "" {
-		test.Namespace = corev1.NamespaceDefault
+		test.Namespace = d.ComponentNamespace
 	}
 
 	if spec.Driver == nil {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -19,7 +19,6 @@ package defaults
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 )
@@ -33,12 +32,13 @@ var _ = Describe("Defaults", func() {
 		loadtest = completeLoadTest.DeepCopy()
 
 		defaults = &Defaults{
-			DriverPool:  "drivers",
-			WorkerPool:  "workers-8core",
-			DriverPort:  10000,
-			ServerPort:  10010,
-			CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
-			DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",
+			ComponentNamespace: "component-default",
+			DriverPool:         "drivers",
+			WorkerPool:         "workers-8core",
+			DriverPort:         10000,
+			ServerPort:         10010,
+			CloneImage:         "gcr.io/grpc-fake-project/test-infra/clone",
+			DriverImage:        "gcr.io/grpc-fake-project/test-infra/driver",
 			Languages: []LanguageDefault{
 				{
 					Language:   "cxx",
@@ -65,9 +65,12 @@ var _ = Describe("Defaults", func() {
 		It("sets default namespace when unset", func() {
 			loadtest.Namespace = ""
 
+			namespace := "foobar-buzz"
+			defaults.ComponentNamespace = namespace
+
 			err := defaults.SetLoadTestDefaults(loadtest)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(loadtest.Namespace).To(Equal(corev1.NamespaceDefault))
+			Expect(loadtest.Namespace).To(Equal(namespace))
 		})
 
 		It("does not override namespace when set", func() {


### PR DESCRIPTION
This commit makes it possible for multiple managers to run on the same cluster, considering resources only in a designated namespace. To do so, it introduces:

 - The `ComponentNamespace` option in the defaults. This is the default namespace for resources created by the controller.

 - The `-namespace` flag. This restricts the controller to only reconcile load tests and their pods in a specific namespace. When omited, all namespaces are considered.

---

**This change allows multiple developers to use managers all working on the same cluster.** To do so, a developer would create a new namespace for themselves. They would modify their config file (see config/example_config.yaml), setting the `componentNamespace` to be their new namespace. Finally, they would start the manager with the `-namespace=<their-namespace>` flag. This would restrict it to reconciling and creating resources in their namespace by default. -- This change should have no effect on the **prod** version.