### PR TITLE
Fix cluster role for listing pods

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,24 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
   - e2etest.grpc.io
   resources:
   - loadtests
@@ -26,21 +44,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - v1
-  resources:
-  - pods
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - v1
-  resources:
-  - pods/status
-  verbs:
-  - get

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -98,8 +98,8 @@ type LoadTestReconciler struct {
 
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=v1,resources=pods,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=v1,resources=pods/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
 
 // Reconcile attempts to bring the current state of the load test into agreement
 // with its declared spec. This may mean provisioning resources, doing nothing


### PR DESCRIPTION
The manager needs to be able to perform CRUD operations on load tests and to create, read and delete pods. The cluster role being generated was insufficient, because it scoped pods to v1. This change updates the role, allowing the manager to work with all pods, regardless of versions.

---

I do not know why it is querying beyond v1 for Pods. Their type is defined in the k8s.io/api/core/v1 package.  There may be a better fix for the future, such as limiting pods to a specific version when listing them. This is something to investigate and improve upon. For now, this fix suffices to deploy to a cluster with proper RBAC.