### PR TITLE
Move controller constants to config package

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -17,26 +17,78 @@ limitations under the License.
 package config
 
 const (
-	// LoadTestLabel is a label which contains the test's unique name.
-	LoadTestLabel = "loadtest"
-
-	// RoleLabel is a label with the role  of a test component. For
-	// example, "loadtest-role=server" indicates a server component.
-	RoleLabel = "loadtest-role"
-
-	// ComponentNameLabel is a label used to distinguish between test
-	// components with the same role.
-	ComponentNameLabel = "loadtest-component"
-
-	// ServerRole is the value the controller expects for the RoleLabel
-	// on a server component.
-	ServerRole = "server"
+	// BuildInitContainerName holds the name of the init container that assembles
+	// a binary or other bundle required to run the tests.
+	BuildInitContainerName = "build"
 
 	// ClientRole is the value the controller expects for the RoleLabel
 	// on a client component.
 	ClientRole = "client"
 
+	// CloneGitRefEnv specifies the name of the env variable that contains the
+	// commit, tag or branch to checkout after cloning a git repository.
+	CloneGitRefEnv = "CLONE_GIT_REF"
+
+	// CloneInitContainerName holds the name of the init container that obtains
+	// a copy of the code at a specific point in time.
+	CloneInitContainerName = "clone"
+
+	// CloneRepoEnv specifies the name of the env variable that contains the git
+	// repository to clone.
+	CloneRepoEnv = "CLONE_REPO"
+
+	// ComponentNameLabel is a label used to distinguish between test
+	// components with the same role.
+	ComponentNameLabel = "loadtest-component"
+
 	// DriverRole is the value the controller expects for the RoleLabel
 	// on a driver component.
 	DriverRole = "driver"
+
+	// LoadTestLabel is a label which contains the test's unique name.
+	LoadTestLabel = "loadtest"
+
+	// ReadyInitContainerName holds the name of the init container that blocks a
+	// driver from running until all worker pods are ready.
+	ReadyInitContainerName = "ready"
+
+	// ReadyMountPath is the absolute path where the ready volume should be
+	// mounted in both the ready init container and the driver's run container.
+	ReadyMountPath = "/var/data/qps_workers"
+
+	// ReadyOutputFile is the name of the file where the ready init container
+	// should write all IP addresses and port numbers for ready workers.
+	ReadyOutputFile = ReadyMountPath + "/addresses"
+
+	// ReadyVolumeName is the name of the volume that permits sharing files
+	// between the ready init container and the driver's run container.
+	ReadyVolumeName = "worker-addresses"
+
+	// RoleLabel is a label with the role  of a test component. For
+	// example, "loadtest-role=server" indicates a server component.
+	RoleLabel = "loadtest-role"
+
+	// RunContainerName holds the name of the main container where the test is
+	// executed.
+	RunContainerName = "run"
+
+	// ScenariosFileEnv specifies the name of an env variable that specifies the
+	// path to a JSON file with scenarios.
+	ScenariosFileEnv = "SCENARIOS_FILE"
+
+	// ScenariosMountPath specifies where the JSON file with the scenario should
+	// be mounted in the driver container.
+	ScenariosMountPath = "/src/scenarios"
+
+	// ServerRole is the value the controller expects for the RoleLabel
+	// on a server component.
+	ServerRole = "server"
+
+	// WorkspaceMountPath contains the path to mount the volume identified by
+	// `workspaceVolume`.
+	WorkspaceMountPath = "/src/workspace"
+
+	// WorkspaceVolumeName contains the name of the volume that is shared between
+	// the init containers and containers for a driver or worker pod.
+	WorkspaceVolumeName = "workspace"
 )

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -37,57 +37,6 @@ import (
 // requests should take for a single invocation of the Reconcile method.
 const reconcileTimeout = 1 * time.Minute
 
-// cloneInitContainer holds the name of the init container that obtains a copy
-// of the code at a specific point in time.
-const cloneInitContainer = "clone"
-
-// buildInitContainer holds the name of the init container that assembles a
-// binary or other bundle required to run the tests.
-const buildInitContainer = "build"
-
-// readyInitContainer holds the name of the init container that blocks a driver
-// from running until all worker pods are ready.
-const readyInitContainer = "ready"
-
-// readyVolume is the name of the volume that permits sharing files between the
-// ready init container and the driver's run container.
-const readyVolume = "worker-addresses"
-
-// readyMountPath is the absolute path where the ready volume should be mounted
-// in both the ready init container and the driver's run container.
-const readyMountPath = "/var/data/qps_workers"
-
-// readyOutputFile is the name of the file where the ready init container should
-// write all IP addresses and port numbers for ready workers.
-const readyOutputFile = readyMountPath + "/addresses"
-
-// runContainer holds the name of the main container where the test is executed.
-const runContainer = "run"
-
-// scenarioMountPath specifies where the JSON file with the scenario should be
-// mounted in the driver container.
-const scenarioMountPath = "/src/scenarios"
-
-// scenariosFileEnv specifies the name of an env variable that specifies the
-// path to a JSON file with scenarios.
-const scenariosFileEnv = "SCENARIOS_FILE"
-
-// CloneRepoEnv specifies the name of the env variable that contains the git
-// repository to clone.
-const CloneRepoEnv = "CLONE_REPO"
-
-// CloneGitRefEnv specifies the name of the env variable that contains the
-// commit, tag or branch to checkout after cloning a git repository.
-const CloneGitRefEnv = "CLONE_GIT_REF"
-
-// workspaceVolume contains the name of the volume that is shared between the
-// init containers and containers for a driver or worker pod.
-const workspaceVolume = "workspace"
-
-// workspaceMountPath contains the path to mount the volume identified by
-// `workspaceVolume`.
-const workspaceMountPath = "/src/workspace"
-
 // LoadTestReconciler reconciles a LoadTest object
 type LoadTestReconciler struct {
 	client.Client
@@ -324,24 +273,24 @@ func newScenarioVolume(scenario string) corev1.Volume {
 func newScenarioVolumeMount(scenario string) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      scenarioVolumeName(scenario),
-		MountPath: scenarioMountPath,
+		MountPath: config.ScenariosMountPath,
 		ReadOnly:  true,
 	}
 }
 
-// newWorkspaceVolume returns an emptyDir volume with `workspaceVolume` as its
-// name.
+// newWorkspaceVolume returns an emptyDir volume with
+// `config.WorkspaceVolumeName` as its name.
 func newWorkspaceVolume() corev1.Volume {
-	return corev1.Volume{Name: workspaceVolume}
+	return corev1.Volume{Name: config.WorkspaceVolumeName}
 }
 
-// newWorkspaceVolumeMount returns a volume mount with `workspaceMountPath` as
-// the path and a reference to the `workspaceVolume`. This volume mount grants
-// read/write access.
+// newWorkspaceVolumeMount returns a volume mount with
+// `config.WorkspaceMountPath` as the path and a reference to the
+// `config.WorkspaceVolumeName`. This volume mount grants read/write access.
 func newWorkspaceVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      workspaceVolume,
-		MountPath: workspaceMountPath,
+		Name:      config.WorkspaceVolumeName,
+		MountPath: config.WorkspaceMountPath,
 		ReadOnly:  false,
 	}
 }
@@ -351,8 +300,8 @@ func newWorkspaceVolumeMount() corev1.VolumeMount {
 func newScenarioFileEnvVar(scenario string) corev1.EnvVar {
 	scenarioFile := strings.ReplaceAll(scenario, "-", "_") + ".json"
 	return corev1.EnvVar{
-		Name:  scenariosFileEnv,
-		Value: scenarioMountPath + "/" + scenarioFile,
+		Name:  config.ScenariosFileEnv,
+		Value: config.ScenariosMountPath + "/" + scenarioFile,
 	}
 }
 
@@ -374,16 +323,16 @@ func addReadyInitContainer(defs *config.Defaults, loadtest *grpcv1.LoadTest, pod
 
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name:  "QPS_WORKERS_FILE",
-		Value: readyOutputFile,
+		Value: config.ReadyOutputFile,
 	})
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      readyVolume,
-		MountPath: readyMountPath,
+		Name:      config.ReadyVolumeName,
+		MountPath: config.ReadyMountPath,
 	})
 
 	podspec.Volumes = append(podspec.Volumes, corev1.Volume{
-		Name: readyVolume,
+		Name: config.ReadyVolumeName,
 	})
 }
 
@@ -464,15 +413,15 @@ func newCloneContainer(clone *grpcv1.Clone) corev1.Container {
 	var env []corev1.EnvVar
 
 	if clone.Repo != nil {
-		env = append(env, corev1.EnvVar{Name: CloneRepoEnv, Value: *clone.Repo})
+		env = append(env, corev1.EnvVar{Name: config.CloneRepoEnv, Value: *clone.Repo})
 	}
 
 	if clone.GitRef != nil {
-		env = append(env, corev1.EnvVar{Name: CloneGitRefEnv, Value: *clone.GitRef})
+		env = append(env, corev1.EnvVar{Name: config.CloneGitRefEnv, Value: *clone.GitRef})
 	}
 
 	return corev1.Container{
-		Name:  cloneInitContainer,
+		Name:  config.CloneInitContainerName,
 		Image: safeStrUnwrap(clone.Image),
 		Env:   env,
 		VolumeMounts: []corev1.VolumeMount{
@@ -489,12 +438,12 @@ func newBuildContainer(build *grpcv1.Build) corev1.Container {
 	}
 
 	return corev1.Container{
-		Name:       buildInitContainer,
+		Name:       config.BuildInitContainerName,
 		Image:      *build.Image,
 		Command:    build.Command,
 		Args:       build.Args,
 		Env:        build.Env,
-		WorkingDir: workspaceMountPath,
+		WorkingDir: config.WorkspaceMountPath,
 		VolumeMounts: []corev1.VolumeMount{
 			newWorkspaceVolumeMount(),
 		},
@@ -525,20 +474,20 @@ func newReadyContainer(defs *config.Defaults, loadtest *grpcv1.LoadTest) corev1.
 	}
 
 	return corev1.Container{
-		Name:    readyInitContainer,
+		Name:    config.ReadyInitContainerName,
 		Image:   defs.ReadyImage,
 		Command: []string{"ready"},
 		Args:    args,
 		Env: []corev1.EnvVar{
 			{
 				Name:  "READY_OUTPUT_FILE",
-				Value: readyOutputFile,
+				Value: config.ReadyOutputFile,
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      readyVolume,
-				MountPath: readyMountPath,
+				Name:      config.ReadyVolumeName,
+				MountPath: config.ReadyMountPath,
 			},
 		},
 	}
@@ -547,12 +496,12 @@ func newReadyContainer(defs *config.Defaults, loadtest *grpcv1.LoadTest) corev1.
 // newRunContainer constructs a container given a grpcv1.Run object.
 func newRunContainer(run grpcv1.Run) corev1.Container {
 	return corev1.Container{
-		Name:       runContainer,
+		Name:       config.RunContainerName,
 		Image:      *run.Image,
 		Command:    run.Command,
 		Args:       run.Args,
 		Env:        run.Env,
-		WorkingDir: workspaceMountPath,
+		WorkingDir: config.WorkspaceMountPath,
 		VolumeMounts: []corev1.VolumeMount{
 			newWorkspaceVolumeMount(),
 		},

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -503,7 +503,7 @@ var _ = Describe("Pod Creation", func() {
 
 		It("sets the name of the container", func() {
 			container := newCloneContainer(clone)
-			Expect(container.Name).To(Equal(cloneInitContainer))
+			Expect(container.Name).To(Equal(config.CloneInitContainerName))
 		})
 
 		It("sets workspace volume mount", func() {
@@ -532,7 +532,7 @@ var _ = Describe("Pod Creation", func() {
 
 			container := newCloneContainer(clone)
 			Expect(container.Env).To(ContainElement(corev1.EnvVar{
-				Name:  CloneRepoEnv,
+				Name:  config.CloneRepoEnv,
 				Value: repo,
 			}))
 		})
@@ -543,7 +543,7 @@ var _ = Describe("Pod Creation", func() {
 
 			container := newCloneContainer(clone)
 			Expect(container.Env).To(ContainElement(corev1.EnvVar{
-				Name:  CloneGitRefEnv,
+				Name:  config.CloneGitRefEnv,
 				Value: gitRef,
 			}))
 		})
@@ -565,7 +565,7 @@ var _ = Describe("Pod Creation", func() {
 
 		It("sets the name of the container", func() {
 			container := newBuildContainer(build)
-			Expect(container.Name).To(Equal(buildInitContainer))
+			Expect(container.Name).To(Equal(config.BuildInitContainerName))
 		})
 
 		It("sets workspace volume mount", func() {
@@ -576,7 +576,7 @@ var _ = Describe("Pod Creation", func() {
 
 		It("sets workspace as working directory", func() {
 			container := newBuildContainer(build)
-			Expect(container.WorkingDir).To(Equal(workspaceMountPath))
+			Expect(container.WorkingDir).To(Equal(config.WorkspaceMountPath))
 		})
 
 		It("returns empty container given nil pointer", func() {
@@ -639,7 +639,7 @@ var _ = Describe("Pod Creation", func() {
 
 		It("sets the name of the container", func() {
 			container := newRunContainer(run)
-			Expect(container.Name).To(Equal(runContainer))
+			Expect(container.Name).To(Equal(config.RunContainerName))
 		})
 
 		It("sets workspace volume mount", func() {
@@ -650,7 +650,7 @@ var _ = Describe("Pod Creation", func() {
 
 		It("sets workspace as working directory", func() {
 			container := newRunContainer(run)
-			Expect(container.WorkingDir).To(Equal(workspaceMountPath))
+			Expect(container.WorkingDir).To(Equal(config.WorkspaceMountPath))
 		})
 
 		It("sets image", func() {


### PR DESCRIPTION
This commit moves most constants that are declared in the controller into the config package. They are alphabetically sorted in a new constants.go file. This change allows the constants to be used across packages.