### PR TITLE
Add optional package with convenience functions

### DIFF
--- a/optional/doc.go
+++ b/optional/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package optional provides convenient functions to declare literals and take
+// their address in a single line.
+package optional

--- a/optional/kubernetes_types.go
+++ b/optional/kubernetes_types.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package optional
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TimePtr accepts a Kubernetes Time object and returns a pointer to it.
+func TimePtr(t metav1.Time) *metav1.Time {
+	return &t
+}
+
+// CurrentTimePtr determines the current time and returns a pointer to a
+// Kubernetes Time representation of it.
+func CurrentTimePtr() *metav1.Time {
+	return TimePtr(metav1.Now())
+}

--- a/optional/primitive_types.go
+++ b/optional/primitive_types.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package optional
+
+// StringPtr accepts a string and returns a pointer to it.
+func StringPtr(str string) *string {
+	return &str
+}
+
+// Int32Ptr accepts a 32-bit integer and returns a pointer to it.
+func Int32Ptr(n int32) *int32 {
+	return &n
+}


### PR DESCRIPTION
Kubernetes often uses pointers to convey optionality. This is true for primitive types, like integers and strings. Since declarations and taking the address of a literal cannot occur on the same line in Go, this commit adds an optional package. This package provides convenient functions to declare and take the address of simple values in one line.