### PR TITLE
Update the status of a load test and prevent restarts

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -243,6 +243,18 @@ const (
 	Errored = "Errored"
 )
 
+// InitContainerError is the reason string when an init container has failed on
+// one of the load test's pods.
+var InitContainerError = "InitContainerError"
+
+// ContainerError is the reason string when a container has failed on one of the
+// load test's pods.
+var ContainerError = "ContainerError"
+
+// PodsMissing is the reason string when the load test is missing pods and is still
+// in the Initializing state.
+var PodsMissing = "PodsMissing"
+
 // LoadTestStatus defines the observed state of LoadTest
 type LoadTestStatus struct {
 	// State identifies the current state of the load test. It is

--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -243,6 +243,12 @@ const (
 	Errored = "Errored"
 )
 
+// IsTerminated returns true if the test has finished due to a success, failure
+// or error. Otherwise, it returns false.
+func (lts LoadTestState) IsTerminated() bool {
+	return lts == Succeeded || lts == Failed || lts == Errored
+}
+
 // InitContainerError is the reason string when an init container has failed on
 // one of the load test's pods.
 var InitContainerError = "InitContainerError"

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -92,6 +92,11 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if loadtest.Status.State.IsTerminated() {
+		// the load test has already completed, this is probably garbage collection
+		return ctrl.Result{}, nil
+	}
+
 	loadtest = loadtest.DeepCopy()
 	if err = r.Defaults.SetLoadTestDefaults(loadtest); err != nil {
 		log.Error(err, "failed to set defaults on loadtest")
@@ -111,10 +116,6 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		log.Error(err, "failed to update loadtest status")
 		return ctrl.Result{Requeue: true}, err
 	}
-
-	// Check if the loadtest has terminated.
-
-	// TODO: Do nothing if the loadtest has terminated.
 
 	var pod *corev1.Pod
 	missingPods := checkMissingPods(loadtest, pods)

--- a/status/status.go
+++ b/status/status.go
@@ -16,8 +16,10 @@ limitations under the License.
 package status
 
 import (
+	"fmt"
 	"strings"
 
+	grpcv1 "github.com/grpc/test-infra/api/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -59,4 +61,39 @@ func StateForContainerStatus(status *corev1.ContainerStatus) (State, *int32) {
 	}
 
 	return Pending, nil
+}
+
+// StateForPodStatus accepts the status of a pod and returns a State, as well
+// as the reason and message. The reason is a camel-case word that is machine
+// comparable. The message is a human-legible description. If the pod has not
+// terminated or it terminated successfully, the reason and message strings will
+// be empty.
+func StateForPodStatus(status *corev1.PodStatus) (state State, reason string, message string) {
+	podState := Pending
+
+	for i := range status.InitContainerStatuses {
+		initContStat := &status.InitContainerStatuses[i]
+		contState, exitCode := StateForContainerStatus(initContStat)
+
+		if contState == Errored {
+			message := fmt.Sprintf("init container %q terminated with exit code %d", initContStat.Name, *exitCode)
+			return Errored, grpcv1.InitContainerError, message
+		}
+	}
+
+	for i := range status.ContainerStatuses {
+		contStat := &status.ContainerStatuses[i]
+		contState, exitCode := StateForContainerStatus(contStat)
+
+		if contState == Errored {
+			message := fmt.Sprintf("container %q terminated with exit code %d", contStat.Name, *exitCode)
+			return Errored, grpcv1.ContainerError, message
+		}
+
+		if contState != Pending {
+			podState = contState
+		}
+	}
+
+	return podState, "", ""
 }

--- a/status/status.go
+++ b/status/status.go
@@ -93,7 +93,7 @@ func StateForPodStatus(status *corev1.PodStatus) (state State, reason string, me
 			return Errored, grpcv1.ContainerError, message
 		}
 
-		if contState != Pending {
+		if (i == 0 && podState == Pending) || contState != Succeeded {
 			podState = contState
 		}
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 gRPC authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package status contains code for determining the current state of
+// the world, including the health of a load test and its resources.
+package status
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// State reflects the observed state of a resource.
+type State string
+
+const (
+	// Pending indicates that the resource has not yet been observed as
+	// succeeding or failing.
+	Pending State = "Pending"
+
+	// Succeeded indicates that the resource has terminated successfully,
+	// marked by a zero exit code.
+	Succeeded State = "Succeeded"
+
+	// Errored indicates that the resource has terminated unsuccessfully,
+	// marked by a non-zero exit code.
+	Errored State = "Errored"
+)
+
+// StateForContainerStatus accepts the status of a container and returns a
+// ContainerState and a pointer to the integer exit code. If the container has
+// not terminated, a Pending state and nil pointer are returned.
+func StateForContainerStatus(status *corev1.ContainerStatus) (State, *int32) {
+	if terminateState := status.State.Terminated; terminateState != nil {
+		var state State = Errored
+
+		if terminateState.ExitCode == 0 {
+			state = Succeeded
+		}
+
+		return state, &terminateState.ExitCode
+	}
+
+	if waitState := status.State.Waiting; waitState != nil {
+		if strings.Compare("CrashLoopBackOff", waitState.Reason) == 0 {
+			return Errored, nil
+		}
+	}
+
+	return Pending, nil
+}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -194,6 +194,23 @@ var _ = Describe("StateForPodStatus", func() {
 			Expect(state).To(Equal(Errored))
 			Expect(reason).To(Equal(grpcv1.ContainerError))
 		})
+
+		It("marks a pod as pending if not all containers have finished", func() {
+			container.State.Terminated = &corev1.ContainerStateTerminated{ExitCode: 0}
+			podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			})
+			podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+				},
+			})
+
+			state, _, _ := StateForPodStatus(podStatus)
+			Expect(state).To(Equal(Pending))
+		})
 	})
 })
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 gRPC authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StateForContainerStatus", func() {
+	var status *corev1.ContainerStatus
+
+	Context("container running", func() {
+		BeforeEach(func() {
+			status = &corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			}
+		})
+
+		It("returns a pending state and nil exit code", func() {
+			state, exitCode := StateForContainerStatus(status)
+			Expect(state).To(Equal(Pending))
+			Expect(exitCode).To(BeNil())
+		})
+	})
+
+	Context("container waiting", func() {
+		BeforeEach(func() {
+			status = &corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{},
+				},
+			}
+		})
+
+		Context("crash detected", func() {
+			It("returns an errored state and nil exit code", func() {
+				status.State.Waiting.Reason = "CrashLoopBackOff"
+				state, exitCode := StateForContainerStatus(status)
+				Expect(state).To(Equal(Errored))
+				Expect(exitCode).To(BeNil())
+			})
+		})
+
+		Context("no crash detected", func() {
+			It("returns a pending state and nil exit code", func() {
+				state, exitCode := StateForContainerStatus(status)
+				Expect(state).To(Equal(Pending))
+				Expect(exitCode).To(BeNil())
+			})
+		})
+	})
+
+	Context("container terminated", func() {
+		BeforeEach(func() {
+			status = &corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+					},
+				},
+			}
+		})
+
+		Context("successful", func() {
+			It("returns a succeeded state and exit code", func() {
+				status.State.Terminated.ExitCode = 0
+
+				state, exitCode := StateForContainerStatus(status)
+				Expect(state).To(Equal(Succeeded))
+				Expect(exitCode).ToNot(BeNil())
+				Expect(*exitCode).To(BeEquivalentTo(0))
+			})
+		})
+
+		Context("unsuccessful", func() {
+			It("returns an errored state and exit code", func() {
+				status.State.Terminated.ExitCode = 127
+
+				state, exitCode := StateForContainerStatus(status)
+				Expect(state).To(Equal(Errored))
+				Expect(exitCode).ToNot(BeNil())
+				Expect(*exitCode).To(BeEquivalentTo(127))
+			})
+		})
+	})
+})


### PR DESCRIPTION
In order to provide success and failure information to a user via a load test resource, the controller needs to diagnose the health at three levels. The container level provides insights about a particular process and its exit code, such as a failure to compile. The pod level provides insights about a pod using the aggregate health of its containers. The load test provides the status of the test using the aggregate health of its pods.

This pull request includes a series of commits to add observations at these three levels. In addition, it adds Reason strings to the load test API. Reason strings are designed to be a part of your API and to be consumed by machines. These reason strings explain the observations that led to the assigned health. Finally, it uses the previous observations to update the status of the load test and to prevent restarts after completion.

Examples of statuses produced by this change:

![Screenshot 2020-09-18 at 11 22 58 AM](https://user-images.githubusercontent.com/1209285/93634702-e4193a00-f9a5-11ea-8c6c-46885bcbafc1.png)
![Screenshot 2020-09-18 at 11 25 40 AM](https://user-images.githubusercontent.com/1209285/93634709-e67b9400-f9a5-11ea-8c0e-319fa46d1a89.png)
![Screenshot 2020-09-18 at 11 31 35 AM](https://user-images.githubusercontent.com/1209285/93634718-e9768480-f9a5-11ea-8b50-f51d2fb8b791.png)
