### PR TITLE
Fix snapshot issue in Dockerfile for driver

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /src/code
 
 RUN git clone https://github.com/$REPOSITORY.git .
 RUN git submodule update --init
+RUN git checkout $GITREF
 
 FROM l.gcr.io/google/bazel:0.17.1
 


### PR DESCRIPTION
The Dockerfile for the driver defines the $GITREF build argument. This allows the driver to be built at a specific tag, commit or branch. Unfortunately, the checkout command that uses this argument was missing. This commit adds it.