### PR TITLE
Add python image suporting python 3.7.

### DIFF
--- a/containers/runtime/python/Dockerfile
+++ b/containers/runtime/python/Dockerfile
@@ -18,7 +18,6 @@ RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
 
 RUN apt-get update && apt-get install -y \
-  gcc \
   git \
   time && \
   apt-get clean

--- a/containers/runtime/python/Dockerfile
+++ b/containers/runtime/python/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.7-buster
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  gcc \
+  git \
+  time && \
+  apt-get clean
+
+CMD ["bash"]


### PR DESCRIPTION
This change adds a Dockerfile for python in the
containers/runtime/python directory.

This image can successfully start a python worker from grpc/grpc.