### PR TITLE
Remove skipped test for GCP credentials

### DIFF
--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -229,11 +229,6 @@ var _ = Describe("Pod Creation", func() {
 			Expect(expectedEnv).To(BeElementOf(rc.Env))
 		})
 
-		It("mounts GCP secrets", func() {
-			// TODO: Add tests for mounting of GCP secrets
-			Skip("complete this task when adding GCP secrets to pkg/defaults")
-		})
-
 		It("sets loadtest-role label to driver", func() {
 			pod, err := newDriverPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
When the test cases for pod creation were written, there was an assumption that GCP credentials would be manually managed. However, the system now relies on workload identity for GKE. Workload identity allows
the Google Cloud Platform to automatically manage credentials on GKE clusters. This commit removes the skipped, now-unnecessary test case.