### PR TITLE
Add support for uploading results to BigQuery

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -17,6 +17,10 @@ limitations under the License.
 package config
 
 const (
+	// BigQueryTableEnv specifies the name of the env variable that holds the name
+	// of the table where results should be written.
+	BigQueryTableEnv = "BQ_RESULT_TABLE"
+
 	// BuildInitContainerName holds the name of the init container that assembles
 	// a binary or other bundle required to run the tests.
 	BuildInitContainerName = "build"

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -75,9 +75,9 @@ RUN pip3 install \
   oauth2client \
   google-auth-oauthlib \
   tabulate \
-  six==1.10.0 \
   pyasn1_modules==0.2.2 \
-  pyasn1==0.4.2
+  pyasn1==0.4.2 \
+  six==1.15.0
 
 COPY . /src/driver
 RUN chmod a+x /src/driver/run.sh

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/config"
+	"github.com/grpc/test-infra/optional"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -320,6 +321,7 @@ var _ = Describe("Pod Creation", func() {
 
 			rc.VolumeMounts = append(rc.VolumeMounts, newScenarioVolumeMount(scenario))
 			rc.Env = append(rc.Env, newScenarioFileEnvVar(scenario))
+			rc.Env = append(rc.Env, newBigQueryTableEnvVar(*loadtest.Spec.Results.BigQueryTable))
 
 			Expect(pod.Spec.Containers).To(ContainElement(rc))
 		})
@@ -336,6 +338,30 @@ var _ = Describe("Pod Creation", func() {
 
 			volume := newWorkspaceVolume()
 			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
+
+		It("sets big query table env variable", func() {
+			table := "example-dataset.table1"
+			loadtest.Spec.Results = &grpcv1.Results{
+				BigQueryTable: optional.StringPtr(table),
+			}
+
+			pod, err := newDriverPod(defs, loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedVar := newBigQueryTableEnvVar(table)
+			Expect(pod.Spec.Containers[0].Env).To(ContainElement(expectedVar))
+		})
+
+		It("does not set big query table env variable when table name not specified", func() {
+			loadtest.Spec.Results = nil
+
+			pod, err := newDriverPod(defs, loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, env := range pod.Spec.Containers[0].Env {
+				Expect(env.Name).ToNot(Equal(config.BigQueryTableEnv))
+			}
 		})
 	})
 


### PR DESCRIPTION
This change sets an environment variable on driver pods that contains the name of a BigQuery table. This table should be where the results of the load test are written. If the load test does not specify a table, this environment variable is not set.