### PR TITLE
Add bazel cache volume

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -17,6 +17,15 @@ limitations under the License.
 package config
 
 const (
+	// BazelCacheVolumeName holds the name of the volume which allows images to
+	// share a bazel cache.
+	BazelCacheVolumeName = "bazel-cache"
+
+	// BazelCacheMountPath stores the directory where the bazel cache resides. For
+	// a description of the bazel image and its cache/output directories, see
+	// https://docs.bazel.build/versions/master/output_directories.html.
+	BazelCacheMountPath = "/root/.cache/bazel"
+
 	// BigQueryTableEnv specifies the name of the env variable that holds the name
 	// of the table where results should be written.
 	BigQueryTableEnv = "BQ_RESULT_TABLE"

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -170,6 +170,14 @@ var _ = Describe("Pod Creation", func() {
 			Expect(container.Args).To(ContainElement(portFlag))
 		})
 
+		It("sets bazel cache volume", func() {
+			pod, err := newClientPod(defs, loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newBazelCacheVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
+
 		It("sets workspace volume", func() {
 			pod, err := newClientPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
@@ -325,6 +333,14 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newDriverPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
+		})
+
+		It("sets bazel cache volume", func() {
+			pod, err := newDriverPod(defs, loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newBazelCacheVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
 		})
 
 		It("sets workspace volume", func() {
@@ -497,6 +513,14 @@ var _ = Describe("Pod Creation", func() {
 			Expect(pod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 		})
 
+		It("sets bazel cache volume", func() {
+			pod, err := newServerPod(defs, loadtest, component)
+			Expect(err).ToNot(HaveOccurred())
+
+			volume := newBazelCacheVolume()
+			Expect(pod.Spec.Volumes).To(ContainElement(volume))
+		})
+
 		It("sets workspace volume", func() {
 			pod, err := newServerPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
@@ -588,6 +612,12 @@ var _ = Describe("Pod Creation", func() {
 			Expect(container.Name).To(Equal(config.BuildInitContainerName))
 		})
 
+		It("sets bazel cache volume mount", func() {
+			container := newBuildContainer(build)
+			volumeMount := newBazelCacheVolumeMount()
+			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
+		})
+
 		It("sets workspace volume mount", func() {
 			container := newBuildContainer(build)
 			volumeMount := newWorkspaceVolumeMount()
@@ -660,6 +690,12 @@ var _ = Describe("Pod Creation", func() {
 		It("sets the name of the container", func() {
 			container := newRunContainer(run)
 			Expect(container.Name).To(Equal(config.RunContainerName))
+		})
+
+		It("sets bazel cache volume mount", func() {
+			container := newRunContainer(run)
+			volumeMount := newBazelCacheVolumeMount()
+			Expect(container.VolumeMounts).To(ContainElement(volumeMount))
 		})
 
 		It("sets workspace volume mount", func() {


### PR DESCRIPTION
The driver and bazel-built workers were failing, because the official bazel image has a complex output behavior. Bazel compiles into a bazel cache directory. Then, it creates links in the bazel-bin and bazel-out directories to the executables in the bazel cache.

This link structure does not allow the build init container to deliver an executable to the run container. The run container lacks the bazel cache available to the build init container. This prevents any executables from being accessible in the run container.

To resolve this issue, this commit introduces a bazel cache volume on all pods. It mounts the volume in the build init container and run container. When languages do not use bazel, the mounted directory is empty and has no effect. When languages use bazel, the mounted directory shares the bazel cache. This allows the bazel-bin and bazel-out links to resolve, making executables accessible to the run container.