### PR TITLE
Change ready init container timeout to 15 minutes

### DIFF
--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -40,7 +40,7 @@ const TimeoutEnv = "READY_TIMEOUT"
 
 // DefaultTimeout specifies the amount of time to wait for ready pods if the
 // environment variable specified by the TimeoutEnv constant is not set.
-const DefaultTimeout = 5 * time.Minute
+const DefaultTimeout = 15 * time.Minute
 
 // OutputFileEnv is the optional name of the file where the executable should
 // write a comma-separated list of IP addresses. If this environment variable is


### PR DESCRIPTION
The ready init container was set to timeout after 5 minutes, marking the test as erroring. Unfortunately, this is not enough time to build the C-based gRPC through bazel. On 2020-10-07, the C++ example scenario took 7 minutes and 8 seconds to compile off gRPC at master and run the test. I would expect that a slow build may exceed 10 minutes. For these reasons, this commit raises the timeout of the ready init container process to 15 minutes.