### PR TITLE
Add flag for reconcile timeouts

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--reconciliation-timeout=2m"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         - /workspace/manager
         args:
         - --enable-leader-election
+        - --reconciliation-timeout=2m
         image: controller:latest
         name: manager
         resources:

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -34,16 +34,13 @@ import (
 	"github.com/grpc/test-infra/config"
 )
 
-// reconcileTimeout specifies the maximum amount of time any set of API
-// requests should take for a single invocation of the Reconcile method.
-const reconcileTimeout = 1 * time.Minute
-
 // LoadTestReconciler reconciles a LoadTest object
 type LoadTestReconciler struct {
 	client.Client
 	Defaults *config.Defaults
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
+	Timeout  time.Duration
 }
 
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests,verbs=get;list;watch;create;update;patch;delete
@@ -55,11 +52,18 @@ type LoadTestReconciler struct {
 // with its declared spec. This may mean provisioning resources, doing nothing
 // or handling the termination of its pods.
 func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	var ctx context.Context
+	var cancel context.CancelFunc
 	var err error
 
-	log := r.Log.WithValues("loadtest", req.NamespacedName)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	if r.Timeout == 0 {
+		ctx, cancel = context.WithCancel(context.Background())
+	} else {
+		ctx, cancel = context.WithTimeout(context.Background(), r.Timeout)
+	}
 	defer cancel()
+
+	log := r.Log.WithValues("loadtest", req.NamespacedName)
 
 	// Fetch the current state of the world.
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -52,9 +53,11 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var namespace string
+	var reconciliationTimeout time.Duration
 	flag.StringVar(&defaultsFile, "defaults-file", "config/defaults.yaml", "The path to a YAML file with a default configuration")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":3777", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "", "Limits resources considered to a specific namespace")
+	flag.DurationVar(&reconciliationTimeout, "reconciliation-timeout", 0, "Timeout for each load test reconciliation")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -97,6 +100,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("LoadTest"),
 		Scheme:   mgr.GetScheme(),
+		Timeout:  reconciliationTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LoadTest")
 		os.Exit(1)


### PR DESCRIPTION
This change removes a magic value and unused constant that were both
intended to set a timeout for a single invocation of the Reconcile
method. It replaces them by adding a `-reconcile-timeout` flag on the
manager. This flag's value is provided to the LoadTestReconciler upon
initialization.

In addition, this commit sets the flag to 2 minutes for the deployment
of the manager and its controller. This number is consistent with the
previous magic value.