### PR TITLE
Send quit RPC to terminate workers after test

### DIFF
--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -22,6 +22,8 @@ fi
 /src/code/bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
   --scenario_result_file='scenario_result.json'
 
+/src/code/bazel-bin/test/cpp/qps/qps_json_driver --quit=true
+
 if [ "$BQ_RESULT_TABLE" != "" ]
 then
   python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="$BQ_RESULT_TABLE"


### PR DESCRIPTION
Previously, after test finishes, the driver will have a status of
complete but the workers will keep running and prevent the next
pod to be assigned to the nodes they are running on. This
change let the driver send a quit RPC to terminate the workers
after the test, once the workers are terminated they would have a
status of complete as the driver. The nodes only have complete
pods are available for next pod assignment.