### PR TITLE
Remove container lookups by index

### DIFF
--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -24,6 +24,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/grpc/test-infra/config"
+	"github.com/grpc/test-infra/kubehelpers"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -44,7 +47,8 @@ var _ = Describe("WaitForReadyPods", func() {
 		irrelevantPod = corev1.Pod{}
 
 		driverPod = newTestPod("driver")
-		driverPod.Spec.Containers[0].Ports = nil
+		driverRunContainer := kubehelpers.ContainerForName(config.RunContainerName, driverPod.Spec.Containers)
+		driverRunContainer.Ports = nil
 
 		serverPod = newTestPod("server")
 		serverPod.Status.PodIP = "127.0.0.2"
@@ -188,7 +192,8 @@ var _ = Describe("WaitForReadyPods", func() {
 		var customPort int32 = 9542
 		client2Pod := newTestPod("client")
 		client2Pod.Name = "client-2"
-		client2Pod.Spec.Containers[0].Ports[0].ContainerPort = customPort
+		client2PodContainer := kubehelpers.ContainerForName(config.RunContainerName, client2Pod.Spec.Containers)
+		client2PodContainer.Ports[0].ContainerPort = customPort
 
 		mock := &PodListerMock{
 			PodList: &corev1.PodList{

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/grpc/test-infra/kubehelpers"
 	"github.com/grpc/test-infra/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,8 +173,8 @@ func newClientPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *g
 		return nil, err
 	}
 
-	addDriverPort(&pod.Spec.Containers[0], defs.DriverPort)
-
+	runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+	addDriverPort(runContainer, defs.DriverPort)
 	return pod, nil
 }
 
@@ -304,8 +305,7 @@ func newDriverPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *g
 	podSpec := &pod.Spec
 	testSpec := &loadtest.Spec
 
-	// TODO: Avoid referencing containers by index, use names
-	testContainer := &podSpec.Containers[0]
+	testContainer := kubehelpers.ContainerForName(config.RunContainerName, podSpec.Containers)
 	addReadyInitContainer(defs, loadtest, podSpec, testContainer)
 
 	// TODO: Handle more than 1 scenario
@@ -359,10 +359,9 @@ func newServerPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *g
 		return nil, err
 	}
 
-	rc := &pod.Spec.Containers[0]
+	rc := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 	addDriverPort(rc, defs.DriverPort)
 	addServerPort(rc, defs.ServerPort)
-
 	return pod, nil
 }
 

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/config"
+	"github.com/grpc/test-infra/kubehelpers"
 	"github.com/grpc/test-infra/optional"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -154,7 +155,9 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newClientPod(defs, loadtest, component)
 			port := newContainerPort("driver", 10000)
 			Expect(err).To(BeNil())
-			Expect(pod.Spec.Containers[0].Ports).To(ContainElement(port))
+
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+			Expect(container.Ports).To(ContainElement(port))
 		})
 
 		It("sets driver port flag in run container args", func() {
@@ -163,9 +166,7 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newClientPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			// TODO: Remove container lookup by index
-			container := &pod.Spec.Containers[0]
-
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 			portFlag := fmt.Sprintf("--driver_port=%d", defs.DriverPort)
 			Expect(container.Args).To(ContainElement(portFlag))
 		})
@@ -221,7 +222,7 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newDriverPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			rc := &pod.Spec.Containers[0]
+			rc := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 			expectedMount := newScenarioVolumeMount(scenario)
 			Expect(expectedMount).To(BeElementOf(rc.VolumeMounts))
 		})
@@ -233,7 +234,7 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newDriverPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			rc := &pod.Spec.Containers[0]
+			rc := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 			expectedEnv := newScenarioFileEnvVar(scenario)
 			Expect(expectedEnv).To(BeElementOf(rc.Env))
 		})
@@ -361,7 +362,8 @@ var _ = Describe("Pod Creation", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedVar := newBigQueryTableEnvVar(table)
-			Expect(pod.Spec.Containers[0].Env).To(ContainElement(expectedVar))
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+			Expect(container.Env).To(ContainElement(expectedVar))
 		})
 
 		It("does not set big query table env variable when table name not specified", func() {
@@ -370,7 +372,8 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newDriverPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			for _, env := range pod.Spec.Containers[0].Env {
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+			for _, env := range container.Env {
 				Expect(env.Name).ToNot(Equal(config.BigQueryTableEnv))
 			}
 		})
@@ -402,7 +405,9 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newServerPod(defs, loadtest, component)
 			port := newContainerPort("driver", 10000)
 			Expect(err).To(BeNil())
-			Expect(pod.Spec.Containers[0].Ports).To(ContainElement(port))
+
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+			Expect(container.Ports).To(ContainElement(port))
 		})
 
 		It("sets driver port flag in run container args", func() {
@@ -411,9 +416,7 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newServerPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			// TODO: Remove container lookup by index
-			container := &pod.Spec.Containers[0]
-
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 			portFlag := fmt.Sprintf("--driver_port=%d", defs.DriverPort)
 			Expect(container.Args).To(ContainElement(portFlag))
 		})
@@ -422,7 +425,9 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newServerPod(defs, loadtest, component)
 			port := newContainerPort("server", 10010)
 			Expect(err).To(BeNil())
-			Expect(pod.Spec.Containers[0].Ports).To(ContainElement(port))
+
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+			Expect(container.Ports).To(ContainElement(port))
 		})
 
 		It("sets server port flag in run container args", func() {
@@ -431,9 +436,7 @@ var _ = Describe("Pod Creation", func() {
 			pod, err := newServerPod(defs, loadtest, component)
 			Expect(err).ToNot(HaveOccurred())
 
-			// TODO: Remove container lookup by index
-			container := &pod.Spec.Containers[0]
-
+			container := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 			portFlag := fmt.Sprintf("--server_port=%d", defs.ServerPort)
 			Expect(container.Args).To(ContainElement(portFlag))
 		})

--- a/kubehelpers/pods.go
+++ b/kubehelpers/pods.go
@@ -1,0 +1,20 @@
+package kubehelpers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ContainerForName accepts a string and a slice of containers. It returns a
+// pointer to the container with a name that matches the string. If no names
+// match, it returns nil.
+func ContainerForName(name string, containers []corev1.Container) *corev1.Container {
+	for i := range containers {
+		container := &containers[i]
+
+		if container.Name == name {
+			return container
+		}
+	}
+
+	return nil
+}

--- a/kubehelpers/pods_test.go
+++ b/kubehelpers/pods_test.go
@@ -1,0 +1,34 @@
+package kubehelpers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("ContainerForName", func() {
+	It("returns nil with an empty list", func() {
+		actual := ContainerForName("match", []corev1.Container{})
+		Expect(actual).To(BeNil())
+	})
+
+	It("returns nil without a matching name", func() {
+		containers := []corev1.Container{
+			{Name: "mismatch"},
+		}
+
+		actual := ContainerForName("match", containers)
+		Expect(actual).To(BeNil())
+	})
+
+	It("returns a pointer to a container with a matching name", func() {
+		containers := []corev1.Container{
+			{Name: "match"},
+			{Name: "mismatch"},
+		}
+
+		expected := &containers[0]
+		actual := ContainerForName("match", containers)
+		Expect(actual).To(BeIdenticalTo(expected))
+	})
+})

--- a/kubehelpers/suite_test.go
+++ b/kubehelpers/suite_test.go
@@ -1,0 +1,13 @@
+package kubehelpers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubehelpers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubehelpers Suite")
+}


### PR DESCRIPTION
Each pod has a list of containers and init containers. In the past, the run container was quickly accessed using index 0. It was the first and only container for pods created by the load test controller. This lookup was not clean, since the introduction of additional containers may lead to bugs.

This change introduces a ContainerForName function in the kubehelpers package. This function iterates over a list of containers. It returns a pointer to the one with a name that matches a given string. This function replaces the index lookups throughout the non-prototype code.