### PR TITLE
Optimize flow of execution for test reconciliation

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -70,6 +70,7 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	rawTest := new(grpcv1.LoadTest)
 	if err = r.Get(ctx, req.NamespacedName, rawTest); err != nil {
 		log.Error(err, "failed to get test", "name", req.NamespacedName)
+		// do not requeue, the test may have been deleted or the cache is invalid
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -67,24 +67,24 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	defer cancel()
 
-	rawLoadtest := new(grpcv1.LoadTest)
-	if err = r.Get(ctx, req.NamespacedName, rawLoadtest); err != nil {
-		log.Error(err, "failed to get loadtest", "name", req.NamespacedName)
+	rawTest := new(grpcv1.LoadTest)
+	if err = r.Get(ctx, req.NamespacedName, rawTest); err != nil {
+		log.Error(err, "failed to get test", "name", req.NamespacedName)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if rawLoadtest.Status.State.IsTerminated() {
+	if rawTest.Status.State.IsTerminated() {
 		return ctrl.Result{}, nil
 	}
 
 	// TODO(codeblooded): Consider moving this to a mutating webhook
-	loadtest := rawLoadtest.DeepCopy()
-	if err = r.Defaults.SetLoadTestDefaults(loadtest); err != nil {
+	test := rawTest.DeepCopy()
+	if err = r.Defaults.SetLoadTestDefaults(test); err != nil {
 		log.Error(err, "failed to clone test with defaults")
 		return ctrl.Result{}, err
 	}
-	if !reflect.DeepEqual(rawLoadtest, loadtest) {
-		if err = r.Update(ctx, loadtest); err != nil {
+	if !reflect.DeepEqual(rawTest, test) {
+		if err = r.Update(ctx, test); err != nil {
 			log.Error(err, "failed to update test with defaults")
 			return ctrl.Result{}, err
 		}
@@ -96,22 +96,22 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	ownedPods := status.PodsForLoadTest(loadtest, pods.Items)
-	loadtest.Status = status.ForLoadTest(loadtest, ownedPods)
-	if err = r.Status().Update(ctx, loadtest); err != nil {
+	ownedPods := status.PodsForLoadTest(test, pods.Items)
+	test.Status = status.ForLoadTest(test, ownedPods)
+	if err = r.Status().Update(ctx, test); err != nil {
 		log.Error(err, "failed to update test status")
 		return ctrl.Result{Requeue: true}, err
 	}
 
 	var pod *corev1.Pod
-	missingPods := status.CheckMissingPods(loadtest, ownedPods)
+	missingPods := status.CheckMissingPods(test, ownedPods)
 
 	if len(missingPods.Servers) > 0 {
-		pod, err = newServerPod(r.Defaults, loadtest, &missingPods.Servers[0].Component)
+		pod, err = newServerPod(r.Defaults, test, &missingPods.Servers[0].Component)
 	} else if len(missingPods.Clients) > 0 {
-		pod, err = newClientPod(r.Defaults, loadtest, &missingPods.Clients[0].Component)
+		pod, err = newClientPod(r.Defaults, test, &missingPods.Clients[0].Component)
 	} else if missingPods.Driver != nil {
-		pod, err = newDriverPod(r.Defaults, loadtest, &missingPods.Driver.Component)
+		pod, err = newDriverPod(r.Defaults, test, &missingPods.Driver.Component)
 	}
 
 	if err != nil {
@@ -120,7 +120,7 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	if pod != nil {
-		if err = ctrl.SetControllerReference(loadtest, pod, r.Scheme); err != nil {
+		if err = ctrl.SetControllerReference(test, pod, r.Scheme); err != nil {
 			log.Error(err, "could not set controller reference on pod, pod will not be garbage collected", "pod", pod)
 			return ctrl.Result{}, err
 		}
@@ -148,8 +148,8 @@ func (r *LoadTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // newClientPod creates a client given defaults, a load test and a reference to
 // the client's component. It returns an error if a pod cannot be constructed.
-func newClientPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
-	pod, err := newPod(loadtest, component, config.ClientRole)
+func newClientPod(defs *config.Defaults, test *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
+	pod, err := newPod(test, component, config.ClientRole)
 	if err != nil {
 		return nil, err
 	}
@@ -243,13 +243,13 @@ func newScenarioFileEnvVar(scenario string) corev1.EnvVar {
 // This method also sets the $QPS_WORKERS_FILE environment variable on the
 // driver's run container. Its value will point to the aforementioned, shared
 // file.
-func addReadyInitContainer(defs *config.Defaults, loadtest *grpcv1.LoadTest, podspec *corev1.PodSpec, container *corev1.Container) {
+func addReadyInitContainer(defs *config.Defaults, test *grpcv1.LoadTest, podspec *corev1.PodSpec, container *corev1.Container) {
 	if defs == nil || podspec == nil || container == nil {
 		return
 	}
 
-	readyCont := newReadyContainer(defs, loadtest)
-	podspec.InitContainers = append(podspec.InitContainers, readyCont)
+	readyContainer := newReadyContainer(defs, test)
+	podspec.InitContainers = append(podspec.InitContainers, readyContainer)
 
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name:  "QPS_WORKERS_FILE",
@@ -277,29 +277,29 @@ func newBigQueryTableEnvVar(tableName string) corev1.EnvVar {
 
 // newDriverPod creates a driver given defaults, a load test and a reference to
 // the driver's component. It returns an error if a pod cannot be constructed.
-func newDriverPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
-	pod, err := newPod(loadtest, component, config.DriverRole)
+func newDriverPod(defs *config.Defaults, test *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
+	pod, err := newPod(test, component, config.DriverRole)
 	if err != nil {
 		return nil, err
 	}
 
 	podSpec := &pod.Spec
-	testSpec := &loadtest.Spec
+	testSpec := &test.Spec
 
-	testContainer := kubehelpers.ContainerForName(config.RunContainerName, podSpec.Containers)
-	addReadyInitContainer(defs, loadtest, podSpec, testContainer)
+	runContainer := kubehelpers.ContainerForName(config.RunContainerName, podSpec.Containers)
+	addReadyInitContainer(defs, test, podSpec, runContainer)
 
 	// TODO: Handle more than 1 scenario
 	if len(testSpec.Scenarios) > 0 {
 		scenario := testSpec.Scenarios[0].Name
 		podSpec.Volumes = append(podSpec.Volumes, newScenarioVolume(scenario))
-		testContainer.VolumeMounts = append(testContainer.VolumeMounts, newScenarioVolumeMount(scenario))
-		testContainer.Env = append(testContainer.Env, newScenarioFileEnvVar(scenario))
+		runContainer.VolumeMounts = append(runContainer.VolumeMounts, newScenarioVolumeMount(scenario))
+		runContainer.Env = append(runContainer.Env, newScenarioFileEnvVar(scenario))
 	}
 
 	if results := testSpec.Results; results != nil {
 		if bigQueryTable := results.BigQueryTable; bigQueryTable != nil {
-			testContainer.Env = append(testContainer.Env, newBigQueryTableEnvVar(*bigQueryTable))
+			runContainer.Env = append(runContainer.Env, newBigQueryTableEnvVar(*bigQueryTable))
 		}
 	}
 
@@ -334,15 +334,15 @@ func newContainerPort(name string, portNumber int32) corev1.ContainerPort {
 
 // newServerPod creates a server given defaults, a load test and a reference to
 // the server's component. It returns an error if a pod cannot be constructed.
-func newServerPod(defs *config.Defaults, loadtest *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
-	pod, err := newPod(loadtest, component, config.ServerRole)
+func newServerPod(defs *config.Defaults, test *grpcv1.LoadTest, component *grpcv1.Component) (*corev1.Pod, error) {
+	pod, err := newPod(test, component, config.ServerRole)
 	if err != nil {
 		return nil, err
 	}
 
-	rc := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
-	addDriverPort(rc, defs.DriverPort)
-	addServerPort(rc, defs.ServerPort)
+	runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+	addDriverPort(runContainer, defs.DriverPort)
+	addServerPort(runContainer, defs.ServerPort)
 	return pod, nil
 }
 
@@ -400,22 +400,22 @@ func newBuildContainer(build *grpcv1.Build) corev1.Container {
 
 // newReadyContainer constructs a container using the default ready container
 // image. If defaults parameter is nil, an empty container is returned.
-func newReadyContainer(defs *config.Defaults, loadtest *grpcv1.LoadTest) corev1.Container {
+func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Container {
 	if defs == nil {
 		return corev1.Container{}
 	}
 
 	var args []string
-	for _, server := range loadtest.Spec.Servers {
+	for _, server := range test.Spec.Servers {
 		args = append(args, fmt.Sprintf("%s=%s,%s=%s,%s=%s",
-			config.LoadTestLabel, loadtest.Name,
+			config.LoadTestLabel, test.Name,
 			config.RoleLabel, config.ServerRole,
 			config.ComponentNameLabel, *server.Name,
 		))
 	}
-	for _, client := range loadtest.Spec.Clients {
+	for _, client := range test.Spec.Clients {
 		args = append(args, fmt.Sprintf("%s=%s,%s=%s,%s=%s",
-			config.LoadTestLabel, loadtest.Name,
+			config.LoadTestLabel, test.Name,
 			config.RoleLabel, config.ClientRole,
 			config.ComponentNameLabel, *client.Name,
 		))
@@ -458,7 +458,7 @@ func newRunContainer(run grpcv1.Run) corev1.Container {
 }
 
 // newPod constructs a Kubernetes pod.
-func newPod(loadtest *grpcv1.LoadTest, component *grpcv1.Component, role string) (*corev1.Pod, error) {
+func newPod(test *grpcv1.LoadTest, component *grpcv1.Component, role string) (*corev1.Pod, error) {
 	var initContainers []corev1.Container
 
 	if component.Clone != nil {
@@ -471,10 +471,10 @@ func newPod(loadtest *grpcv1.LoadTest, component *grpcv1.Component, role string)
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s-%s", loadtest.Name, role, *component.Name),
-			Namespace: loadtest.Namespace,
+			Name:      fmt.Sprintf("%s-%s-%s", test.Name, role, *component.Name),
+			Namespace: test.Namespace,
 			Labels: map[string]string{
-				config.LoadTestLabel:      loadtest.Name,
+				config.LoadTestLabel:      test.Name,
 				config.RoleLabel:          role,
 				config.ComponentNameLabel: *component.Name,
 			},

--- a/status/missing_pods.go
+++ b/status/missing_pods.go
@@ -41,7 +41,7 @@ type LoadTestMissing struct {
 // the current load test. It takes reference of the current load test and a pod
 // list that contains all running pods at the moment, returning all missing
 // components required from the current load test with their roles.
-func CheckMissingPods(currentLoadTest *grpcv1.LoadTest, ownedPods []*corev1.Pod) *LoadTestMissing {
+func CheckMissingPods(test *grpcv1.LoadTest, ownedPods []*corev1.Pod) *LoadTestMissing {
 
 	currentMissing := &LoadTestMissing{Servers: []grpcv1.Server{}, Clients: []grpcv1.Client{}}
 
@@ -49,11 +49,11 @@ func CheckMissingPods(currentLoadTest *grpcv1.LoadTest, ownedPods []*corev1.Pod)
 	requiredServerMap := make(map[string]*grpcv1.Server)
 	foundDriver := false
 
-	for i := 0; i < len(currentLoadTest.Spec.Clients); i++ {
-		requiredClientMap[*currentLoadTest.Spec.Clients[i].Name] = &currentLoadTest.Spec.Clients[i]
+	for i := 0; i < len(test.Spec.Clients); i++ {
+		requiredClientMap[*test.Spec.Clients[i].Name] = &test.Spec.Clients[i]
 	}
-	for i := 0; i < len(currentLoadTest.Spec.Servers); i++ {
-		requiredServerMap[*currentLoadTest.Spec.Servers[i].Name] = &currentLoadTest.Spec.Servers[i]
+	for i := 0; i < len(test.Spec.Servers); i++ {
+		requiredServerMap[*test.Spec.Servers[i].Name] = &test.Spec.Servers[i]
 	}
 
 	if ownedPods != nil {
@@ -68,7 +68,7 @@ func CheckMissingPods(currentLoadTest *grpcv1.LoadTest, ownedPods []*corev1.Pod)
 			componentNameLabel := eachPod.Labels[config.ComponentNameLabel]
 
 			if roleLabel == config.DriverRole {
-				if *currentLoadTest.Spec.Driver.Component.Name == componentNameLabel {
+				if *test.Spec.Driver.Component.Name == componentNameLabel {
 					foundDriver = true
 				}
 			} else if roleLabel == config.ClientRole {
@@ -92,7 +92,7 @@ func CheckMissingPods(currentLoadTest *grpcv1.LoadTest, ownedPods []*corev1.Pod)
 	}
 
 	if !foundDriver {
-		currentMissing.Driver = currentLoadTest.Spec.Driver
+		currentMissing.Driver = test.Spec.Driver
 	}
 
 	return currentMissing

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -26,30 +26,30 @@ import (
 
 var _ = Describe("CheckMissingPods", func() {
 
-	var currentLoadTest *grpcv1.LoadTest
+	var test *grpcv1.LoadTest
 	var allRunningPods []*corev1.Pod
 	var actualReturn *LoadTestMissing
 	var expectedReturn *LoadTestMissing
 
 	BeforeEach(func() {
-		currentLoadTest = newLoadTestWithMultipleClientsAndServers()
+		test = newLoadTestWithMultipleClientsAndServers()
 		allRunningPods = []*corev1.Pod{}
 		expectedReturn = &LoadTestMissing{Clients: []grpcv1.Client{}, Servers: []grpcv1.Server{}}
 	})
 
 	Context("no pods from the current load test is running", func() {
 		BeforeEach(func() {
-			for i := 0; i < len(currentLoadTest.Spec.Clients); i++ {
-				expectedReturn.Clients = append(expectedReturn.Clients, currentLoadTest.Spec.Clients[i])
+			for i := 0; i < len(test.Spec.Clients); i++ {
+				expectedReturn.Clients = append(expectedReturn.Clients, test.Spec.Clients[i])
 			}
-			for i := 0; i < len(currentLoadTest.Spec.Servers); i++ {
-				expectedReturn.Servers = append(expectedReturn.Servers, currentLoadTest.Spec.Servers[i])
+			for i := 0; i < len(test.Spec.Servers); i++ {
+				expectedReturn.Servers = append(expectedReturn.Servers, test.Spec.Servers[i])
 			}
-			expectedReturn.Driver = currentLoadTest.Spec.Driver
+			expectedReturn.Driver = test.Spec.Driver
 		})
 
 		It("returns the full pod list from the current load test", func() {
-			actualReturn = CheckMissingPods(currentLoadTest, allRunningPods)
+			actualReturn = CheckMissingPods(test, allRunningPods)
 			Expect(actualReturn.Clients).To(ConsistOf(expectedReturn.Clients))
 			Expect(actualReturn.Servers).To(ConsistOf(expectedReturn.Servers))
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))
@@ -91,21 +91,21 @@ var _ = Describe("CheckMissingPods", func() {
 					},
 				},
 			)
-			for i := 0; i < len(currentLoadTest.Spec.Clients); i++ {
-				if *currentLoadTest.Spec.Clients[i].Name != "client-2" {
-					expectedReturn.Clients = append(expectedReturn.Clients, currentLoadTest.Spec.Clients[i])
+			for i := 0; i < len(test.Spec.Clients); i++ {
+				if *test.Spec.Clients[i].Name != "client-2" {
+					expectedReturn.Clients = append(expectedReturn.Clients, test.Spec.Clients[i])
 				}
 			}
 
-			for i := 0; i < len(currentLoadTest.Spec.Servers); i++ {
-				if *currentLoadTest.Spec.Servers[i].Name != "server-1" {
-					expectedReturn.Servers = append(expectedReturn.Servers, currentLoadTest.Spec.Servers[i])
+			for i := 0; i < len(test.Spec.Servers); i++ {
+				if *test.Spec.Servers[i].Name != "server-1" {
+					expectedReturn.Servers = append(expectedReturn.Servers, test.Spec.Servers[i])
 				}
 			}
 		})
 
 		It("returns the list of pods missing from collection of running pods", func() {
-			actualReturn = CheckMissingPods(currentLoadTest, allRunningPods)
+			actualReturn = CheckMissingPods(test, allRunningPods)
 			Expect(actualReturn.Clients).To(ConsistOf(expectedReturn.Clients))
 			Expect(actualReturn.Servers).To(ConsistOf(expectedReturn.Servers))
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))
@@ -116,11 +116,11 @@ var _ = Describe("CheckMissingPods", func() {
 	Context("all of pods from the current load test is running", func() {
 
 		BeforeEach(func() {
-			allRunningPods = populatePodListWithCurrentLoadTestPod(currentLoadTest)
+			allRunningPods = populatePodListWithCurrentLoadTestPod(test)
 		})
 
 		It("returns a empty list", func() {
-			actualReturn = CheckMissingPods(currentLoadTest, allRunningPods)
+			actualReturn = CheckMissingPods(test, allRunningPods)
 			Expect(actualReturn.Clients).To(ConsistOf(expectedReturn.Clients))
 			Expect(actualReturn.Servers).To(ConsistOf(expectedReturn.Servers))
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))

--- a/status/relationships_test.go
+++ b/status/relationships_test.go
@@ -40,26 +40,26 @@ var _ = Describe("PodsForLoadTest", func() {
 	})
 
 	It("returns empty when no pods are supplied", func() {
-		loadtest := new(grpcv1.LoadTest)
-		loadtest.Name = "empty-pods-loadtest"
+		test := new(grpcv1.LoadTest)
+		test.Name = "empty-pods-loadtest"
 
-		pods := PodsForLoadTest(loadtest, nil)
+		pods := PodsForLoadTest(test, nil)
 		Expect(pods).To(BeEmpty())
 
-		pods = PodsForLoadTest(loadtest, []corev1.Pod{})
+		pods = PodsForLoadTest(test, []corev1.Pod{})
 		Expect(pods).To(BeEmpty())
 	})
 
 	It("includes only pods with matching labels", func() {
-		loadtest := new(grpcv1.LoadTest)
-		loadtest.Name = "pods-matching-labels-loadtest"
+		test := new(grpcv1.LoadTest)
+		test.Name = "pods-matching-labels-loadtest"
 
 		allPods := []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "good-pod-1",
 					Labels: map[string]string{
-						config.LoadTestLabel: loadtest.Name,
+						config.LoadTestLabel: test.Name,
 					},
 				},
 			},
@@ -75,7 +75,7 @@ var _ = Describe("PodsForLoadTest", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "good-pod-2",
 					Labels: map[string]string{
-						config.LoadTestLabel: loadtest.Name,
+						config.LoadTestLabel: test.Name,
 					},
 				},
 			},
@@ -87,7 +87,7 @@ var _ = Describe("PodsForLoadTest", func() {
 			},
 		}
 
-		pods := PodsForLoadTest(loadtest, allPods)
+		pods := PodsForLoadTest(test, allPods)
 		Expect(pods).To(ConsistOf(&allPods[0], &allPods[2]))
 	})
 })

--- a/status/status.go
+++ b/status/status.go
@@ -105,13 +105,13 @@ func StateForPodStatus(status *corev1.PodStatus) (state State, reason string, me
 // pods it owns. This sets the state, reason and message for the load test. In
 // addition, it attempts to set the start and stop times based on what has been
 // previously encountered.
-func ForLoadTest(loadtest *grpcv1.LoadTest, pods []*corev1.Pod) grpcv1.LoadTestStatus {
+func ForLoadTest(test *grpcv1.LoadTest, pods []*corev1.Pod) grpcv1.LoadTestStatus {
 	status := grpcv1.LoadTestStatus{}
 
-	if loadtest.Status.StartTime == nil {
+	if test.Status.StartTime == nil {
 		status.StartTime = optional.CurrentTimePtr()
 	} else {
-		status.StartTime = loadtest.Status.StartTime
+		status.StartTime = test.Status.StartTime
 	}
 
 	for _, pod := range pods {
@@ -146,17 +146,17 @@ func ForLoadTest(loadtest *grpcv1.LoadTest, pods []*corev1.Pod) grpcv1.LoadTestS
 			status.State = grpcv1.Errored
 		}
 
-		if loadtest.Status.StopTime == nil {
+		if test.Status.StopTime == nil {
 			status.StopTime = optional.CurrentTimePtr()
 		} else {
-			status.StopTime = loadtest.Status.StopTime
+			status.StopTime = test.Status.StopTime
 		}
 
 		return status
 	}
 
 	currentPods := len(pods)
-	requiredPods := len(loadtest.Spec.Servers) + len(loadtest.Spec.Clients) + 1
+	requiredPods := len(test.Spec.Servers) + len(test.Spec.Clients) + 1
 
 	if currentPods < requiredPods {
 		status.State = grpcv1.Initializing

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -215,14 +215,14 @@ var _ = Describe("StateForPodStatus", func() {
 })
 
 var _ = Describe("ForLoadTest", func() {
-	var loadtest *grpcv1.LoadTest
+	var test *grpcv1.LoadTest
 	var pods []*corev1.Pod
 	var driverPod, serverPod, clientPod *corev1.Pod
 
 	BeforeEach(func() {
-		loadtest = &grpcv1.LoadTest{
+		test = &grpcv1.LoadTest{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "loadtest-for-unit-tests",
+				Name: "test-for-unit-tests",
 			},
 			Spec: grpcv1.LoadTestSpec{
 				Driver: &grpcv1.Driver{
@@ -261,7 +261,7 @@ var _ = Describe("ForLoadTest", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "driver",
 					Labels: map[string]string{
-						config.LoadTestLabel:      loadtest.Name,
+						config.LoadTestLabel:      test.Name,
 						config.RoleLabel:          config.DriverRole,
 						config.ComponentNameLabel: "driver",
 					},
@@ -271,7 +271,7 @@ var _ = Describe("ForLoadTest", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "server-1",
 					Labels: map[string]string{
-						config.LoadTestLabel:      loadtest.Name,
+						config.LoadTestLabel:      test.Name,
 						config.RoleLabel:          config.ServerRole,
 						config.ComponentNameLabel: "server-1",
 					},
@@ -281,7 +281,7 @@ var _ = Describe("ForLoadTest", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "client-1",
 					Labels: map[string]string{
-						config.LoadTestLabel:      loadtest.Name,
+						config.LoadTestLabel:      test.Name,
 						config.RoleLabel:          config.ClientRole,
 						config.ComponentNameLabel: "client-1",
 					},
@@ -301,7 +301,7 @@ var _ = Describe("ForLoadTest", func() {
 	It("sets start time when unset", func() {
 		testStart := metav1.Now()
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.StartTime).ToNot(BeNil())
 		Expect(testStart.Before(status.StartTime)).To(BeTrue())
@@ -309,9 +309,9 @@ var _ = Describe("ForLoadTest", func() {
 
 	It("does not override start time when set", func() {
 		fakeStartTime := metav1.Now()
-		loadtest.Status.StartTime = &fakeStartTime
+		test.Status.StartTime = &fakeStartTime
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.StartTime).To(Equal(&fakeStartTime))
 	})
@@ -341,7 +341,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).To(BeEquivalentTo(grpcv1.Succeeded))
 	})
@@ -371,7 +371,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).ToNot(BeEquivalentTo(grpcv1.Succeeded))
 	})
@@ -401,7 +401,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).To(BeEquivalentTo(grpcv1.Failed))
 	})
@@ -439,7 +439,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).To(BeEquivalentTo(grpcv1.Errored))
 	})
@@ -469,7 +469,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).To(BeEquivalentTo(grpcv1.Errored))
 	})
@@ -501,7 +501,7 @@ var _ = Describe("ForLoadTest", func() {
 			},
 		}
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.StopTime).ToNot(BeNil())
 		Expect(testStart.Before(status.StopTime)).To(BeTrue())
@@ -533,9 +533,9 @@ var _ = Describe("ForLoadTest", func() {
 		}
 
 		stopTime := optional.CurrentTimePtr()
-		loadtest.Status.StopTime = stopTime
+		test.Status.StopTime = stopTime
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.StopTime).ToNot(BeNil())
 		Expect(*status.StopTime).To(Equal(*stopTime))
@@ -544,7 +544,7 @@ var _ = Describe("ForLoadTest", func() {
 	It("sets initializing state when pods are missing", func() {
 		pods = pods[1:] // remove the driver from the world
 
-		status := ForLoadTest(loadtest, pods)
+		status := ForLoadTest(test, pods)
 
 		Expect(status.State).To(BeEquivalentTo(grpcv1.Initializing))
 	})


### PR DESCRIPTION
The previous flow of execution for the (*LoadTestReconciler).Reconcile method included pre-emptively fetching resources and making unnecessary calls to account for defaults. Aside from the unnecessary requests, the flow was hard to follow.

This change reorders the method, removing unnecessary calls and switching to fetch resources lazily.