### PR TITLE
Remove load test controller from top-level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: manager
+all: controller
 
 # Run tests
 test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
-# Build manager binary
-manager: generate fmt vet
-	go build -o bin/manager main.go
+# Build controller manager binary
+controller: generate fmt vet
+	go build -o bin/controller cmd/controller/main.go
 
 # Install CRDs into a cluster
 install: manifests
@@ -61,11 +61,11 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the manager image with the controller
-manager-image:
-	docker build . -t ${IMG}
+controller-image:
+	docker build -t ${IMG} -f containers/runtime/controller/Dockerfile .
 
-# Push the manager image to a docker registry
-push-manager-image:
+# Push the controller manager image to a docker registry
+push-controller-image:
 	docker push ${IMG}
 
 # Build the clone init container image
@@ -149,7 +149,7 @@ all-images: \
 	java-image \
 	ruby-image \
 	python-image \
-	manager-image
+	controller-image
 
 # Push all init container and runtime container images to a docker registry
 push-all-images: \
@@ -161,7 +161,7 @@ push-all-images: \
 	push-java-image \
 	push-ruby-image \
 	push-python-image \
-	push-manager-image
+	push-controller-image
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,6 @@ test: generate fmt vet manifests
 manager: generate fmt vet
 	go build -o bin/manager main.go
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
-	go run ./main.go
-
 # Install CRDs into a cluster
 install: manifests
 	kustomize build config/crd | kubectl apply -f -

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -37,13 +37,13 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme             = runtime.NewScheme()
+	setupLog           = ctrl.Log.WithName("setup")
+	errMissingDefaults = errors.New("missing flag -defaults-file")
 )
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-
 	_ = grpcv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
@@ -54,19 +54,18 @@ func main() {
 	var enableLeaderElection bool
 	var namespace string
 	var reconciliationTimeout time.Duration
-	flag.StringVar(&defaultsFile, "defaults-file", "config/defaults.yaml", "The path to a YAML file with a default configuration")
-	flag.StringVar(&metricsAddr, "metrics-addr", ":3777", "The address the metric endpoint binds to.")
-	flag.StringVar(&namespace, "namespace", "", "Limits resources considered to a specific namespace")
-	flag.DurationVar(&reconciliationTimeout, "reconciliation-timeout", 0, "Timeout for each load test reconciliation")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+
+	flag.StringVar(&defaultsFile, "defaults-file", "config/defaults.yaml", "Path to a YAML file with a default configuration.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":3777", "Address the metrics endpoint binds to.")
+	flag.StringVar(&namespace, "namespace", "", "Limits resources considered to a specific namespace.")
+	flag.DurationVar(&reconciliationTimeout, "reconciliation-timeout", 0, "Timeout for each load test reconciliation.")
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election (ensures only one controller is active).")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	if defaultsFile == "" {
-		setupLog.Error(errors.New("missing defaultsFile flag"), "cannot start without defaults")
+		setupLog.Error(errMissingDefaults, "cannot start without defaults")
 		os.Exit(1)
 	}
 

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -14,10 +14,10 @@ COPY . .
 RUN chmod 777 /workspace/config/defaults.yaml
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/controller cmd/controller/main.go
 
 FROM debian:buster
 WORKDIR /workspace
 COPY --from=builder /workspace .
-CMD ["/workspace/manager"]
+CMD ["/workspace/bin/controller"]
 


### PR DESCRIPTION
The grpc/test-infra repository contained the manager for the load test controller and its Dockerfile at the top-most level. This change moves it the image into the containers/ directory and introduces a cmd/ directory for the manager executable. It also renames the make target from "manager" to "controller".