### PR TITLE
Optimize branch checkouts in clone init container

### DIFF
--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -17,5 +17,4 @@ set -ex
 
 cd /src/workspace
 ls -A | xargs -r rm -fr
-git clone --recursive $CLONE_REPO .
-git checkout $CLONE_GIT_REF
+git clone --recursive $CLONE_REPO --branch $CLONE_GIT_REF --single-branch .


### PR DESCRIPTION
This change optimizes the checkout of a branch or tag for the clone init container. Previously, repositories were cloned off the master branch. This commit switches to cloning a specific, single-branch only.

Unfortunately, this breaks checking out a commit hash, because a tree must be downloaded for git to resolve a specific commit.