### PR TITLE
Report the status and error when defaults fail

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -247,6 +247,10 @@ var InitContainerError = "InitContainerError"
 // load test's pods.
 var ContainerError = "ContainerError"
 
+// FailedSettingDefaultsError is the reason string when defaults could not be
+// set on a load test.
+var FailedSettingDefaultsError = "FailedSettingDefaults"
+
 // PodsMissing is the reason string when the load test is missing pods and is still
 // in the Initializing state.
 var PodsMissing = "PodsMissing"


### PR DESCRIPTION
Setting and using defaults on a load test may fail. For instance, consider a load test that specifies an unknown language for a component. If the test does explicitly set images, the controller will try to add them using defaults. Since the language is unknown, there are no default images to fallback on. In this case, the test component could not be scheduled.

When this would occur, there was no update to the status of the test. The test would not officially terminate, and the error was only visible in the controller logs. This change updates the status of the load test if there is a problem with the defaults. It terminates it and includes the precise error in the test's status.

The status of the load test shows the exact issue:

```
Status:
  Message:  failed to reconcile tests with defaults: could not set defaults for server at index 0: could not infer default build image: cannot find image for language "fighorn"
  Reason:   FailedSettingDefaults
  State:    Errored
```

/cc @jtattermusch [addresses issue from friction log]