### PR TITLE
Remove unnecessary checkouts when cloning

### DIFF
--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 set -ex
-
 cd /src/workspace
 ls -A | xargs -r rm -fr
-git clone --recursive $CLONE_REPO .
-git checkout $CLONE_GIT_REF
+git init
+git remote add origin $CLONE_REPO
+git fetch
+git reset --hard $CLONE_GIT_REF
+git submodule update --init --recursive
+chmod -R 777 .


### PR DESCRIPTION
The clone docker image is used as an init container which fetches the code at a specific commit, tag or branch. Previously, it used the git-clone command, which clones the master branch by default. Developers wanted to avoid the unnecessary checkout when they are testing off another branch or tag.

The git-clone command does provide the --branch and --single-branch flags, but these options are incompatible with commits due to a server-side setting that GitHub has not enabled. See https://stackoverflow.com/questions/3489173/how-to-clone-git-repository-with-specific-revision-changeset.

This commit achieves similar behavior, but it uses an empty git repository, fetches a remote and resets to a specific branch, tag or commit. This avoids the unnecessary checkout.