### PR TITLE
Fix git-reset unresolved issue in clone container

### DIFF
--- a/containers/init/clone/clone.sh
+++ b/containers/init/clone/clone.sh
@@ -19,6 +19,6 @@ ls -A | xargs -r rm -fr
 git init
 git remote add origin $CLONE_REPO
 git fetch
-git reset --hard $CLONE_GIT_REF
+git checkout $CLONE_GIT_REF
 git submodule update --init --recursive
 chmod -R 777 .


### PR DESCRIPTION
The clone container grabs a copy of the repository at a specific snapshot. The process was updated in #86. As part of the change, the git-reset command was used. Unfortunately, this does not properly resolve the snapshot.  This change fixes the issue by replacing git-reset with git-checkout.