### PR TITLE
Remove gRPC version from driver image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ push-ready-image:
 # Build the driver container image at the $DRIVER_VERSION
 driver-image:
 	docker build --build-arg GITREF=${DRIVER_VERSION} \
-		-t ${IMAGE_PREFIX}driver:${TEST_INFRA_VERSION}-grpc${DRIVER_VERSION} \
+		-t ${IMAGE_PREFIX}driver:${TEST_INFRA_VERSION} \
 		containers/runtime/driver
 
 # Push the driver container image to a docker regisry


### PR DESCRIPTION
The driver-image make target builds the driver from grpc/grpc at the version specified by the $DRIVER_VERSION environment variable. It tags the image with the $TEST_INFRA_VERSION environment variable and the $DRIVER_VERSION.

This does not match the configuration template config/defaults_template.yaml. This change removes the $DRIVER_VERSION from the tag.