### PR TITLE
Fix command for controller in manager YAML

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - command:
-        - /workspace/manager
+        - /workspace/bin/controller
         args:
         - --enable-leader-election
         - --reconciliation-timeout=2m


### PR DESCRIPTION
The containers/runtime/controller Dockerfile describes how to build and run the controller. The CMD declared in this file is overridden at runtime by the config/manager/manager.yaml file. When the name of the CMD was changed in commit 42d613dbbcc, the manager YAML was not updated. This broke the deployed controller. This change fixes the YAML to use the correct executable.