### PR TITLE
Add Visual Studio Code files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/*
 *~
 *.orig
 .idea/
+.vscode/
 
 # Hide internal configs
 config/defaults.yaml


### PR DESCRIPTION
To prevent them from accidentally being checked into source control.