### PR TITLE
Fix controller RBAC permissions and ConfigMap ownership for embedded Scenarios

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
 - ./roles
 - ./bindings
-
+- ./role.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -49,6 +49,7 @@ type LoadTestReconciler struct {
 // +kubebuilder:rbac:groups=e2etest.grpc.io,resources=loadtests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile attempts to bring the current state of the load test into agreement
 // with its declared spec. This may mean provisioning resources, doing nothing

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -209,6 +209,7 @@ func (r *LoadTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&grpcv1.LoadTest{}).
 		Owns(&corev1.Pod{}).
+		Owns(&corev1.ConfigMap{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
In order to get, create and delete ConfigMap resources; these
permissions must be specified in the ClusterRole resource that is
assigned to the controller. This commit adds the markers and generated
code to set these permissions.

Every reconciler declares the relationship between a resource and the
subresources it creates. Despite the LoadTestReconciler creating config
maps in #94, it did not declare ownership of them. This means that
Reconcile was not invoked when the ConfigMap resources changed.
This change also denotes the relationship between a LoadTest resource and a
ConfigMap resource. It is a best practice.

This change is required to embed scenarios in a production environment
and serves as a required follow-up to #92.
