### PR TITLE
Remove driverPort and serverPort from defaults

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -58,8 +58,9 @@ const (
 	// on a driver component.
 	DriverRole = "driver"
 
-	// DriverPort is the port through which the driver and workers
-	// communicate.
+	// DriverPort is the number of the port that the servers and clients expose
+	// for the driver to connect to. This connection allows the driver to send
+	// instructions and receive results from the servers and clients.
 	DriverPort = 10000
 
 	// LoadTestLabel is a label which contains the test's unique name.

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -36,14 +36,6 @@ type Defaults struct {
 	// components should be scheduled by default.
 	WorkerPool string `json:"workerPool"`
 
-	// DriverPort is the port through which the driver and workers
-	// communicate.
-	DriverPort int32 `json:"driverPort"`
-
-	// ServerPort is the port through which a server component accepts
-	// traffic from a client component.
-	ServerPort int32 `json:"serverPort"`
-
 	// CloneImage specifies the default container image to use for
 	// cloning Git repositories at a specific snapshot.
 	CloneImage string `json:"cloneImage"`
@@ -65,22 +57,12 @@ type Defaults struct {
 // value. If an issue is encountered, an error is returned. If the defaults are
 // valid, nil is returned.
 func (d *Defaults) Validate() error {
-	var tcpPortMax int32 = 65535
-
 	if d.DriverPool == "" {
 		return errors.New("missing driver pool")
 	}
 
 	if d.WorkerPool == "" {
 		return errors.New("missing worker pool")
-	}
-
-	if d.DriverPort < 0 || d.DriverPort > tcpPortMax {
-		return errors.Errorf("driver port is outside of TCP range: [0, %d]", tcpPortMax)
-	}
-
-	if d.ServerPort < 0 || d.ServerPort > tcpPortMax {
-		return errors.Errorf("server port is outside of TCP range: [0, %d]", tcpPortMax)
 	}
 
 	if d.CloneImage == "" {

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -1,9 +1,5 @@
 # See ./defaults.go for documentation on each field.
 
-driverPort: 10000
-
-serverPort: 10010
-
 driverPool: "{{ .DriverPool }}"
 
 workerPool: "{{ .WorkerPool }}"

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -31,8 +31,6 @@ var _ = Describe("Defaults", func() {
 			ComponentNamespace: "component-default",
 			DriverPool:         "drivers",
 			WorkerPool:         "workers-8core",
-			DriverPort:         10000,
-			ServerPort:         10010,
 			CloneImage:         "gcr.io/grpc-fake-project/test-infra/clone",
 			ReadyImage:         "gcr.io/grpc-fake-project/test-infra/ready",
 			DriverImage:        "gcr.io/grpc-fake-project/test-infra/driver",
@@ -66,26 +64,6 @@ var _ = Describe("Defaults", func() {
 		It("returns an error when missing a worker pool", func() {
 			defaults.WorkerPool = ""
 			err := defaults.Validate()
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an when the driver port is out of range", func() {
-			defaults.DriverPort = -1
-			err := defaults.Validate()
-			Expect(err).To(HaveOccurred())
-
-			defaults.DriverPort = 65536
-			err = defaults.Validate()
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an when the server port is out of range", func() {
-			defaults.ServerPort = -1
-			err := defaults.Validate()
-			Expect(err).To(HaveOccurred())
-
-			defaults.ServerPort = 65536
-			err = defaults.Validate()
 			Expect(err).To(HaveOccurred())
 		})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -83,8 +83,6 @@ func newDefaults() *config.Defaults {
 	return &config.Defaults{
 		DriverPool:  "drivers",
 		WorkerPool:  "workers-8core",
-		DriverPort:  10000,
-		ServerPort:  10010,
 		CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
 		ReadyImage:  "gcr.io/grpc-fake-project/test-infra/ready",
 		DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -135,11 +135,11 @@ func (pb *PodBuilder) PodForClient(client *grpcv1.Client) *corev1.Pod {
 
 	runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 
-	runContainer.Args = append(runContainer.Args, fmt.Sprintf("--driver_port=%d", pb.defaults.DriverPort))
+	runContainer.Args = append(runContainer.Args, fmt.Sprintf("--driver_port=%d", config.DriverPort))
 	runContainer.Ports = append(runContainer.Ports, corev1.ContainerPort{
 		Name:          "driver",
 		Protocol:      corev1.ProtocolTCP,
-		ContainerPort: pb.defaults.DriverPort,
+		ContainerPort: config.DriverPort,
 	})
 
 	return pod
@@ -204,11 +204,11 @@ func (pb *PodBuilder) PodForServer(server *grpcv1.Server) *corev1.Pod {
 
 	runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 
-	runContainer.Args = append(runContainer.Args, fmt.Sprintf("--driver_port=%d", pb.defaults.DriverPort))
+	runContainer.Args = append(runContainer.Args, fmt.Sprintf("--driver_port=%d", config.DriverPort))
 	runContainer.Ports = append(runContainer.Ports, corev1.ContainerPort{
 		Name:          "driver",
 		Protocol:      corev1.ProtocolTCP,
-		ContainerPort: pb.defaults.DriverPort,
+		ContainerPort: config.DriverPort,
 	})
 
 	return pod

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -279,7 +279,7 @@ var _ = Describe("PodBuilder", func() {
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 				Expect(getNames(runContainer.Ports)).To(ContainElement("driver"))
-				Expect(getValue("driver", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(defaults.DriverPort))
+				Expect(getValue("driver", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(config.DriverPort))
 			})
 
 			It("appends the driver port command line argument", func() {
@@ -291,7 +291,7 @@ var _ = Describe("PodBuilder", func() {
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
-				Expect(runContainer.Args).To(ContainElement(fmt.Sprintf("--driver_port=%d", defaults.DriverPort)))
+				Expect(runContainer.Args).To(ContainElement(fmt.Sprintf("--driver_port=%d", config.DriverPort)))
 			})
 		})
 
@@ -503,7 +503,7 @@ var _ = Describe("PodBuilder", func() {
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
 				Expect(getNames(runContainer.Ports)).To(ContainElement("driver"))
-				Expect(getValue("driver", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(defaults.DriverPort))
+				Expect(getValue("driver", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(config.DriverPort))
 			})
 
 			It("appends the driver port command line argument", func() {
@@ -515,7 +515,7 @@ var _ = Describe("PodBuilder", func() {
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
-				Expect(runContainer.Args).To(ContainElement(fmt.Sprintf("--driver_port=%d", defaults.DriverPort)))
+				Expect(runContainer.Args).To(ContainElement(fmt.Sprintf("--driver_port=%d", config.DriverPort)))
 			})
 		})
 

--- a/podbuilder/suite_test.go
+++ b/podbuilder/suite_test.go
@@ -82,8 +82,6 @@ func newDefaults() *config.Defaults {
 	return &config.Defaults{
 		DriverPool:  "drivers",
 		WorkerPool:  "workers-8core",
-		DriverPort:  10000,
-		ServerPort:  10010,
 		CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
 		ReadyImage:  "gcr.io/grpc-fake-project/test-infra/ready",
 		DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",


### PR DESCRIPTION
This change removes the driverPort from the defaults, since we always rely on port 10000. The serverPort is also removed, since Kubernetes permits communication amongst pods on all ports.