### PR TITLE
Replace default pools with default pool labels

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -365,6 +365,9 @@ var ContainerError = "ContainerError"
 // set on a load test.
 var FailedSettingDefaultsError = "FailedSettingDefaults"
 
+// ConfigurationError is the reason string when a LoadTest spec is invalid.
+var ConfigurationError = "ConfigurationError"
+
 // PodsMissing is the reason string when the load test is missing pods and is still
 // in the Initializing state.
 var PodsMissing = "PodsMissing"

--- a/config/cmd/configure.go
+++ b/config/cmd/configure.go
@@ -38,8 +38,6 @@ import (
 // defaults template file.
 type DefaultsData struct {
 	Version         string
-	DriverPool      string
-	WorkerPool      string
 	InitImagePrefix string
 	ImagePrefix     string
 }
@@ -73,16 +71,6 @@ func main() {
 
 	flag.StringVar(&data.Version, "version", "latest", "version of all docker images to use")
 
-	flag.StringVar(&data.DriverPool, "driver-pool", "", `pool where drivers are scheduled by default (required)
-
-Drivers will be scheduled by default on nodes with a "pool" label that
-matches this -driver-pool flag.`)
-
-	flag.StringVar(&data.WorkerPool, "worker-pool", "", `pool where workers are scheduled by default (required)
-
-Workers will be scheduled by default on nodes with a "pool" label that
-matches this -worker-pool flag.`)
-
 	flag.StringVar(&data.InitImagePrefix, "init-image-prefix", "", `prefix to append to init container images (optional)
 
 This -init-image-prefix flag allows a specific prefix to apply to all
@@ -99,14 +87,6 @@ container images that are not used as init containers.`)
 
 	if flag.NArg() != 2 {
 		exitWithErrorf(1, true, "missing required arguments")
-	}
-
-	if data.DriverPool == "" {
-		exitWithErrorf(1, true, "missing required -driver-pool flag")
-	}
-
-	if data.WorkerPool == "" {
-		exitWithErrorf(1, true, "missing required -worker-pool flag")
 	}
 
 	templ, err := template.ParseFiles(flag.Arg(0))

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -1,8 +1,9 @@
 # See ./defaults.go for documentation on each field.
 
-driverPool: "{{ .DriverPool }}"
-
-workerPool: "{{ .WorkerPool }}"
+defaultPoolLabels:
+  client: default-client-pool
+  driver: default-driver-pool
+  server: default-server-pool
 
 cloneImage: "{{ .InitImagePrefix }}clone:{{ .Version }}"
 

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -29,11 +29,14 @@ var _ = Describe("Defaults", func() {
 	BeforeEach(func() {
 		defaults = &Defaults{
 			ComponentNamespace: "component-default",
-			DriverPool:         "drivers",
-			WorkerPool:         "workers-8core",
-			CloneImage:         "gcr.io/grpc-fake-project/test-infra/clone",
-			ReadyImage:         "gcr.io/grpc-fake-project/test-infra/ready",
-			DriverImage:        "gcr.io/grpc-fake-project/test-infra/driver",
+			DefaultPoolLabels: &PoolLabelMap{
+				Client: "default-client-pool",
+				Driver: "default-driver-pool",
+				Server: "default-server-pool",
+			},
+			CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
+			ReadyImage:  "gcr.io/grpc-fake-project/test-infra/ready",
+			DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",
 			Languages: []LanguageDefault{
 				{
 					Language:   "cxx",
@@ -55,18 +58,6 @@ var _ = Describe("Defaults", func() {
 	})
 
 	Describe("Validate", func() {
-		It("returns an error when missing a driver pool", func() {
-			defaults.DriverPool = ""
-			err := defaults.Validate()
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error when missing a worker pool", func() {
-			defaults.WorkerPool = ""
-			err := defaults.Validate()
-			Expect(err).To(HaveOccurred())
-		})
-
 		It("returns an error when missing the clone image", func() {
 			defaults.CloneImage = ""
 			err := defaults.Validate()
@@ -171,14 +162,6 @@ var _ = Describe("Defaults", func() {
 				err := defaults.SetLoadTestDefaults(loadtest)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(driver.Name).ToNot(BeNil())
-			})
-
-			It("sets default pool when unspecified", func() {
-				driver.Pool = nil
-				err := defaults.SetLoadTestDefaults(loadtest)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(driver.Pool).ToNot(BeNil())
-				Expect(*driver.Pool).To(Equal(defaults.DriverPool))
 			})
 
 			It("does not override pool when specified", func() {
@@ -288,14 +271,6 @@ var _ = Describe("Defaults", func() {
 				err := defaults.SetLoadTestDefaults(loadtest)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(server.Name).ToNot(BeNil())
-			})
-
-			It("sets default pool when unspecified", func() {
-				server.Pool = nil
-				err := defaults.SetLoadTestDefaults(loadtest)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(server.Pool).ToNot(BeNil())
-				Expect(*server.Pool).To(Equal(defaults.WorkerPool))
 			})
 
 			It("does not override pool when specified", func() {
@@ -419,14 +394,6 @@ var _ = Describe("Defaults", func() {
 				err := defaults.SetLoadTestDefaults(loadtest)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(client.Name).ToNot(BeNil())
-			})
-
-			It("sets default pool when unspecified", func() {
-				client.Pool = nil
-				err := defaults.SetLoadTestDefaults(loadtest)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(client.Pool).ToNot(BeNil())
-				Expect(*client.Pool).To(Equal(defaults.WorkerPool))
 			})
 
 			It("does not override pool when specified", func() {

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -172,19 +172,23 @@ var _ = Describe("LoadTest controller", func() {
 		builder := podbuilder.New(newDefaults(), test)
 		testSpec := &test.Spec
 		var pod *corev1.Pod
+		var err error
 		for i := range testSpec.Servers {
-			pod = builder.PodForServer(&testSpec.Servers[i])
+			pod, err = builder.PodForServer(&testSpec.Servers[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
 		for i := range testSpec.Clients {
-			pod = builder.PodForClient(&testSpec.Clients[i])
+			pod, err = builder.PodForClient(&testSpec.Clients[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, errorState)).To(Succeed())
 
 		}
 		if testSpec.Driver != nil {
-			pod = builder.PodForDriver(testSpec.Driver)
+			pod, err = builder.PodForDriver(testSpec.Driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
@@ -225,19 +229,23 @@ var _ = Describe("LoadTest controller", func() {
 		builder := podbuilder.New(newDefaults(), test)
 		testSpec := &test.Spec
 		var pod *corev1.Pod
+		var err error
 		for i := range testSpec.Servers {
-			pod = builder.PodForServer(&testSpec.Servers[i])
+			pod, err = builder.PodForServer(&testSpec.Servers[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
 		for i := range testSpec.Clients {
-			pod = builder.PodForClient(&testSpec.Clients[i])
+			pod, err = builder.PodForClient(&testSpec.Clients[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 
 		}
 		if testSpec.Driver != nil {
-			pod = builder.PodForDriver(testSpec.Driver)
+			pod, err = builder.PodForDriver(testSpec.Driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, errorState)).To(Succeed())
 		}
@@ -278,19 +286,23 @@ var _ = Describe("LoadTest controller", func() {
 		builder := podbuilder.New(newDefaults(), test)
 		testSpec := &test.Spec
 		var pod *corev1.Pod
+		var err error
 		for i := range testSpec.Servers {
-			pod = builder.PodForServer(&testSpec.Servers[i])
+			pod, err = builder.PodForServer(&testSpec.Servers[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, errorState)).To(Succeed())
 		}
 		for i := range testSpec.Clients {
-			pod = builder.PodForClient(&testSpec.Clients[i])
+			pod, err = builder.PodForClient(&testSpec.Clients[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 
 		}
 		if testSpec.Driver != nil {
-			pod = builder.PodForDriver(testSpec.Driver)
+			pod, err = builder.PodForDriver(testSpec.Driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
@@ -326,19 +338,23 @@ var _ = Describe("LoadTest controller", func() {
 		builder := podbuilder.New(newDefaults(), test)
 		testSpec := &test.Spec
 		var pod *corev1.Pod
+		var err error
 		for i := range testSpec.Servers {
-			pod = builder.PodForServer(&testSpec.Servers[i])
+			pod, err = builder.PodForServer(&testSpec.Servers[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
 		for i := range testSpec.Clients {
-			pod = builder.PodForClient(&testSpec.Clients[i])
+			pod, err = builder.PodForClient(&testSpec.Clients[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 
 		}
 		if testSpec.Driver != nil {
-			pod = builder.PodForDriver(testSpec.Driver)
+			pod, err = builder.PodForDriver(testSpec.Driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, runningState)).To(Succeed())
 		}
@@ -376,19 +392,23 @@ var _ = Describe("LoadTest controller", func() {
 		builder := podbuilder.New(newDefaults(), test)
 		testSpec := &test.Spec
 		var pod *corev1.Pod
+		var err error
 		for i := range testSpec.Servers {
-			pod = builder.PodForServer(&testSpec.Servers[i])
+			pod, err = builder.PodForServer(&testSpec.Servers[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, successState)).To(Succeed())
 		}
 		for i := range testSpec.Clients {
-			pod = builder.PodForClient(&testSpec.Clients[i])
+			pod, err = builder.PodForClient(&testSpec.Clients[i])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, successState)).To(Succeed())
 
 		}
 		if testSpec.Driver != nil {
-			pod = builder.PodForDriver(testSpec.Driver)
+			pod, err = builder.PodForDriver(testSpec.Driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createPod(pod, test)).To(Succeed())
 			Expect(updatePodWithContainerState(pod, successState)).To(Succeed())
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -81,8 +81,11 @@ var nodes = func() []*corev1.Node {
 
 func newDefaults() *config.Defaults {
 	return &config.Defaults{
-		DriverPool:  "drivers",
-		WorkerPool:  "workers-8core",
+		DefaultPoolLabels: &config.PoolLabelMap{
+			Driver: "default-driver-pool",
+			Client: "default-client-pool",
+			Server: "default-server-pool",
+		},
 		CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
 		ReadyImage:  "gcr.io/grpc-fake-project/test-infra/ready",
 		DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -131,6 +131,28 @@ var _ = Describe("PodBuilder", func() {
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*client.Pool))
 		})
 
+		It("sets node selector to default pool when applicable", func() {
+			client.Pool = nil
+
+			defaultPool := "default-test-pool"
+			builder.defaults.DefaultPoolLabels.Client = defaultPool
+
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
+
+			defaultPoolValue, defaultPoolPresent := pod.Spec.NodeSelector[defaultPool]
+			Expect(defaultPoolPresent).To(BeTrue())
+			Expect(defaultPoolValue).To(Equal("true"))
+		})
+
+		It("errors when no pool is specified and no defaults are set", func() {
+			client.Pool = nil
+			builder.defaults.DefaultPoolLabels = nil
+
+			_, err := builder.PodForClient(client)
+			Expect(err).To(HaveOccurred())
+		})
+
 		Context("clone init container", func() {
 			It("contains an init container named clone when clone instructions are present", func() {
 				client.Clone = new(grpcv1.Clone)
@@ -379,6 +401,28 @@ var _ = Describe("PodBuilder", func() {
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*server.Pool))
 		})
 
+		It("sets node selector to default pool when applicable", func() {
+			server.Pool = nil
+
+			defaultPool := "default-test-pool"
+			builder.defaults.DefaultPoolLabels.Server = defaultPool
+
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
+
+			defaultPoolValue, defaultPoolPresent := pod.Spec.NodeSelector[defaultPool]
+			Expect(defaultPoolPresent).To(BeTrue())
+			Expect(defaultPoolValue).To(Equal("true"))
+		})
+
+		It("errors when no pool is specified and no defaults are set", func() {
+			server.Pool = nil
+			builder.defaults.DefaultPoolLabels = nil
+
+			_, err := builder.PodForServer(server)
+			Expect(err).To(HaveOccurred())
+		})
+
 		Context("clone init container", func() {
 			It("contains an init container named clone when clone instructions are present", func() {
 				server.Clone = new(grpcv1.Clone)
@@ -623,6 +667,28 @@ var _ = Describe("PodBuilder", func() {
 
 			Expect(pod.Spec.NodeSelector).ToNot(BeNil())
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*driver.Pool))
+		})
+
+		It("sets node selector to default pool when applicable", func() {
+			driver.Pool = nil
+
+			defaultPool := "default-test-pool"
+			builder.defaults.DefaultPoolLabels.Driver = defaultPool
+
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
+
+			defaultPoolValue, defaultPoolPresent := pod.Spec.NodeSelector[defaultPool]
+			Expect(defaultPoolPresent).To(BeTrue())
+			Expect(defaultPoolValue).To(Equal("true"))
+		})
+
+		It("errors when no pool is specified and no defaults are set", func() {
+			driver.Pool = nil
+			builder.defaults.DefaultPoolLabels = nil
+
+			_, err := builder.PodForDriver(driver)
+			Expect(err).To(HaveOccurred())
 		})
 
 		Context("clone init container", func() {

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -89,26 +89,33 @@ var _ = Describe("PodBuilder", func() {
 		})
 
 		It("sets the namespace to match the test", func() {
-			pod := builder.PodForClient(client)
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Namespace).To(Equal(test.Namespace))
 		})
 
 		It("sets a label with the name of the load test", func() {
-			pod := builder.PodForClient(client)
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
+
 			testName, ok := pod.ObjectMeta.Labels[config.LoadTestLabel]
 			Expect(ok).To(BeTrue())
 			Expect(testName).To(Equal(test.Name))
 		})
 
 		It("sets a label indicating it is a client", func() {
-			pod := builder.PodForClient(client)
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
+
 			role, ok := pod.ObjectMeta.Labels[config.RoleLabel]
 			Expect(ok).To(BeTrue())
 			Expect(role).To(Equal(config.ClientRole))
 		})
 
 		It("sets a label with the name of the client", func() {
-			pod := builder.PodForClient(client)
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
+
 			componentName, ok := pod.ObjectMeta.Labels[config.ComponentNameLabel]
 			Expect(ok).To(BeTrue())
 			Expect(componentName).To(Equal(*client.Name))
@@ -116,7 +123,10 @@ var _ = Describe("PodBuilder", func() {
 
 		It("sets node selector to match pool", func() {
 			client.Pool = optional.StringPtr("testing-pool")
-			pod := builder.PodForClient(client)
+
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(pod.Spec.NodeSelector).ToNot(BeNil())
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*client.Pool))
 		})
@@ -127,7 +137,9 @@ var _ = Describe("PodBuilder", func() {
 				client.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				client.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
+
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.CloneInitContainerName))
 			})
@@ -135,7 +147,9 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named clone when clone instructions are not present", func() {
 				client.Clone = nil
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
+
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.CloneInitContainerName))
 			})
@@ -145,7 +159,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				client.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -168,7 +183,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				client.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -191,7 +207,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				client.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -209,7 +226,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Build.Command = []string{"go"}
 				client.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 			})
@@ -217,7 +235,8 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named build when build instructions are not present", func() {
 				client.Build = nil
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.BuildInitContainerName))
 			})
@@ -227,7 +246,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Build.Command = []string{"go"}
 				client.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 
@@ -240,7 +260,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Build.Command = []string{"go"}
 				client.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				buildContainer := kubehelpers.ContainerForName(config.BuildInitContainerName, pod.Spec.InitContainers)
@@ -258,7 +279,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Run.Command = []string{"go"}
 				client.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -274,7 +296,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Run.Command = []string{"go"}
 				client.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -287,7 +310,8 @@ var _ = Describe("PodBuilder", func() {
 				client.Run.Command = []string{"go"}
 				client.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForClient(client)
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -299,7 +323,8 @@ var _ = Describe("PodBuilder", func() {
 			// Note: this is a simple test to ensure the anti-affinity is set.
 			// It does not confirm its properties are correct. This check is
 			// meant to guard against accidental deletions of anti-affinities.
-			pod := builder.PodForClient(client)
+			pod, err := builder.PodForClient(client)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.Affinity).ToNot(BeNil())
 			Expect(pod.Spec.Affinity.PodAntiAffinity).ToNot((BeNil()))
 		})
@@ -313,26 +338,33 @@ var _ = Describe("PodBuilder", func() {
 		})
 
 		It("sets the namespace to match the test", func() {
-			pod := builder.PodForServer(server)
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Namespace).To(Equal(test.Namespace))
 		})
 
 		It("sets a label with the name of the load test", func() {
-			pod := builder.PodForServer(server)
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
+
 			testName, ok := pod.ObjectMeta.Labels[config.LoadTestLabel]
 			Expect(ok).To(BeTrue())
 			Expect(testName).To(Equal(test.Name))
 		})
 
 		It("sets a label indicating it is a server", func() {
-			pod := builder.PodForServer(server)
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
+
 			role, ok := pod.ObjectMeta.Labels[config.RoleLabel]
 			Expect(ok).To(BeTrue())
 			Expect(role).To(Equal(config.ServerRole))
 		})
 
 		It("sets a label with the name of the server", func() {
-			pod := builder.PodForServer(server)
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
+
 			componentName, ok := pod.ObjectMeta.Labels[config.ComponentNameLabel]
 			Expect(ok).To(BeTrue())
 			Expect(componentName).To(Equal(*server.Name))
@@ -340,7 +372,9 @@ var _ = Describe("PodBuilder", func() {
 
 		It("sets node selector to match pool", func() {
 			server.Pool = optional.StringPtr("testing-pool")
-			pod := builder.PodForServer(server)
+
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.NodeSelector).ToNot(BeNil())
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*server.Pool))
 		})
@@ -351,7 +385,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				server.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.CloneInitContainerName))
 			})
@@ -359,7 +394,8 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named clone when clone instructions are not present", func() {
 				server.Clone = nil
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.CloneInitContainerName))
 			})
@@ -369,7 +405,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				server.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -392,7 +429,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				server.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -415,7 +453,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				server.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -433,7 +472,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Build.Command = []string{"go"}
 				server.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 			})
@@ -441,7 +481,8 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named build when build instructions are not present", func() {
 				server.Build = nil
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.BuildInitContainerName))
 			})
@@ -451,7 +492,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Build.Command = []string{"go"}
 				server.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 
@@ -464,7 +506,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Build.Command = []string{"go"}
 				server.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				buildContainer := kubehelpers.ContainerForName(config.BuildInitContainerName, pod.Spec.InitContainers)
@@ -482,7 +525,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Run.Command = []string{"go"}
 				server.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -498,7 +542,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Run.Command = []string{"go"}
 				server.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -511,7 +556,8 @@ var _ = Describe("PodBuilder", func() {
 				server.Run.Command = []string{"go"}
 				server.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForServer(server)
+				pod, err := builder.PodForServer(server)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -523,7 +569,8 @@ var _ = Describe("PodBuilder", func() {
 			// Note: this is a simple test to ensure the anti-affinity is set.
 			// It does not confirm its properties are correct. This check is
 			// meant to guard against accidental deletions of anti-affinities.
-			pod := builder.PodForServer(server)
+			pod, err := builder.PodForServer(server)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.Affinity).ToNot(BeNil())
 			Expect(pod.Spec.Affinity.PodAntiAffinity).ToNot((BeNil()))
 		})
@@ -537,26 +584,32 @@ var _ = Describe("PodBuilder", func() {
 		})
 
 		It("sets the namespace to match the test", func() {
-			pod := builder.PodForDriver(driver)
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Namespace).To(Equal(test.Namespace))
 		})
 
 		It("sets a label with the name of the load test", func() {
-			pod := builder.PodForDriver(driver)
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
+
 			testName, ok := pod.ObjectMeta.Labels[config.LoadTestLabel]
 			Expect(ok).To(BeTrue())
 			Expect(testName).To(Equal(test.Name))
 		})
 
 		It("sets a label indicating it is a driver", func() {
-			pod := builder.PodForDriver(driver)
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
+
 			role, ok := pod.ObjectMeta.Labels[config.RoleLabel]
 			Expect(ok).To(BeTrue())
 			Expect(role).To(Equal(config.DriverRole))
 		})
 
 		It("sets a label with the name of the driver", func() {
-			pod := builder.PodForDriver(driver)
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
 			componentName, ok := pod.ObjectMeta.Labels[config.ComponentNameLabel]
 			Expect(ok).To(BeTrue())
 			Expect(componentName).To(Equal(*driver.Name))
@@ -564,7 +617,10 @@ var _ = Describe("PodBuilder", func() {
 
 		It("sets node selector to match pool", func() {
 			driver.Pool = optional.StringPtr("testing-pool")
-			pod := builder.PodForDriver(driver)
+
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(pod.Spec.NodeSelector).ToNot(BeNil())
 			Expect(pod.Spec.NodeSelector["pool"]).To(Equal(*driver.Pool))
 		})
@@ -575,7 +631,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				driver.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.CloneInitContainerName))
 			})
@@ -583,7 +640,8 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named clone when clone instructions are not present", func() {
 				driver.Clone = nil
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.CloneInitContainerName))
 			})
@@ -593,7 +651,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				driver.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -616,7 +675,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				driver.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -639,7 +699,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Clone.Repo = optional.StringPtr("https://github.com/grpc/test-infra.git")
 				driver.Clone.GitRef = optional.StringPtr("master")
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				cloneContainer := kubehelpers.ContainerForName(config.CloneInitContainerName, pod.Spec.InitContainers)
@@ -657,7 +718,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Build.Command = []string{"go"}
 				driver.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 			})
@@ -665,7 +727,8 @@ var _ = Describe("PodBuilder", func() {
 			It("does not contain an init container named build when build instructions are not present", func() {
 				driver.Build = nil
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).ToNot(ContainElement(config.BuildInitContainerName))
 			})
@@ -675,7 +738,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Build.Command = []string{"go"}
 				driver.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 				Expect(getNames(pod.Spec.InitContainers)).To(ContainElement(config.BuildInitContainerName))
 
@@ -688,7 +752,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Build.Command = []string{"go"}
 				driver.Build.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.InitContainers).ToNot(BeEmpty())
 
 				buildContainer := kubehelpers.ContainerForName(config.BuildInitContainerName, pod.Spec.InitContainers)
@@ -706,7 +771,8 @@ var _ = Describe("PodBuilder", func() {
 				driver.Run.Command = []string{"go"}
 				driver.Run.Args = []string{"run", "main.go"}
 
-				pod := builder.PodForDriver(driver)
+				pod, err := builder.PodForDriver(driver)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers).ToNot(BeEmpty())
 
 				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
@@ -722,7 +788,8 @@ var _ = Describe("PodBuilder", func() {
 			// Note: this is a simple test to ensure the anti-affinity is set.
 			// It does not confirm its properties are correct. This check is
 			// meant to guard against accidental deletions of anti-affinities.
-			pod := builder.PodForDriver(driver)
+			pod, err := builder.PodForDriver(driver)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.Affinity).ToNot(BeNil())
 			Expect(pod.Spec.Affinity.PodAntiAffinity).ToNot((BeNil()))
 		})

--- a/podbuilder/suite_test.go
+++ b/podbuilder/suite_test.go
@@ -80,8 +80,11 @@ var nodes = func() []*corev1.Node {
 
 func newDefaults() *config.Defaults {
 	return &config.Defaults{
-		DriverPool:  "drivers",
-		WorkerPool:  "workers-8core",
+		DefaultPoolLabels: &config.PoolLabelMap{
+			Client: "default-client-pool",
+			Driver: "default-driver-pool",
+			Server: "default-server-pool",
+		},
 		CloneImage:  "gcr.io/grpc-fake-project/test-infra/clone",
 		ReadyImage:  "gcr.io/grpc-fake-project/test-infra/ready",
 		DriverImage: "gcr.io/grpc-fake-project/test-infra/driver",


### PR DESCRIPTION
This commit removes the requirement for the names of default pools to be specified in the defaults configuration. Instead, it adds the option to specify the name of a default pool label for a client, driver and server. Therefore, the workflow becomes:

 - If the user has specified a pool for a client, driver or server; its pod will be scheduled on a node with a matching value for the "pool" label.

 - If the user has not specified a pool but the defaults configuration specifies default pool labels, the pod will be scheduled on a node with the appropriate label present. For example, consider a LoadTest with a client that has no pool specified. The defaults configuration specifies "default-pool-client" as the string for the client field on the defaultPoolLabels struct. The client's pod will be scheduled on any node with a label named "default-pool-client" and a string value of "true".

 - If the user does not specify a pool and there are no default pool labels, the LoadTest will error.