### PR TITLE
Rename cleanup agent test suite

### DIFF
--- a/cleanup/suite_test.go
+++ b/cleanup/suite_test.go
@@ -53,7 +53,7 @@ func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Cleanup Agent Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 


### PR DESCRIPTION
Let's rename the cleanup test suite to **Cleanup Agent Suite** in order to distinguish it from the **Controller Suite**.