### PR TITLE
Remove redundancies across test suites

### DIFF
--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
+	"github.com/grpc/test-infra/testutil"
 )
 
 var _ = Describe("Defaults", func() {
@@ -114,7 +115,7 @@ var _ = Describe("Defaults", func() {
 		var defaultImageMap *imageMap
 
 		BeforeEach(func() {
-			loadtest = completeLoadTest.DeepCopy()
+			loadtest = testutil.NewLoadTest(1, 1)
 			defaultImageMap = newImageMap(defaults.Languages)
 		})
 
@@ -537,93 +538,3 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 })
-
-var completeLoadTest = func() *grpcv1.LoadTest {
-	cloneImage := "docker.pkg.github.com/grpc/test-infra/clone"
-	cloneRepo := "https://github.com/grpc/grpc.git"
-	cloneGitRef := "master"
-
-	buildImage := "l.gcr.io/google/bazel:latest"
-	buildCommand := []string{"bazel"}
-	buildArgs := []string{"build", "//test/cpp/qps:qps_worker"}
-
-	driverImage := "docker.pkg.github.com/grpc/test-infra/driver"
-	runImage := "docker.pkg.github.com/grpc/test-infra/cxx"
-	runCommand := []string{"bazel-bin/test/cpp/qps/qps_worker"}
-	clientRunArgs := []string{"--driver_port=10000"}
-	serverRunArgs := append(clientRunArgs, "--server_port=10010")
-
-	bigQueryTable := "grpc-testing.e2e_benchmark.foobarbuzz"
-
-	driverPool := "drivers"
-	workerPool := "workers-8core"
-
-	driverComponentName := "driver"
-	serverComponentName := "server"
-	clientComponentName := "client-1"
-
-	return &grpcv1.LoadTest{
-		Spec: grpcv1.LoadTestSpec{
-			Driver: &grpcv1.Driver{
-				Name:     &driverComponentName,
-				Language: "cxx",
-				Pool:     &driverPool,
-				Run: grpcv1.Run{
-					Image: &driverImage,
-				},
-			},
-
-			Servers: []grpcv1.Server{
-				{
-					Name:     &serverComponentName,
-					Language: "cxx",
-					Pool:     &workerPool,
-					Clone: &grpcv1.Clone{
-						Image:  &cloneImage,
-						Repo:   &cloneRepo,
-						GitRef: &cloneGitRef,
-					},
-					Build: &grpcv1.Build{
-						Image:   &buildImage,
-						Command: buildCommand,
-						Args:    buildArgs,
-					},
-					Run: grpcv1.Run{
-						Image:   &runImage,
-						Command: runCommand,
-						Args:    serverRunArgs,
-					},
-				},
-			},
-
-			Clients: []grpcv1.Client{
-				{
-					Name:     &clientComponentName,
-					Language: "cxx",
-					Pool:     &workerPool,
-					Clone: &grpcv1.Clone{
-						Image:  &cloneImage,
-						Repo:   &cloneRepo,
-						GitRef: &cloneGitRef,
-					},
-					Build: &grpcv1.Build{
-						Image:   &buildImage,
-						Command: buildCommand,
-						Args:    buildArgs,
-					},
-					Run: grpcv1.Run{
-						Image:   &runImage,
-						Command: runCommand,
-						Args:    clientRunArgs,
-					},
-				},
-			},
-
-			Results: &grpcv1.Results{
-				BigQueryTable: &bigQueryTable,
-			},
-
-			ScenariosJSON: "{\"scenarios\": []}",
-		},
-	}
-}()

--- a/controllers/loadtest_controller_test.go
+++ b/controllers/loadtest_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grpc/test-infra/config"
 	"github.com/grpc/test-infra/podbuilder"
 	"github.com/grpc/test-infra/status"
+	"github.com/grpc/test-infra/testutil"
 )
 
 // createPod creates a pod resource, given a pod pointer and a test pointer.
@@ -58,7 +59,7 @@ var _ = Describe("LoadTest controller", func() {
 	var namespacedName types.NamespacedName
 
 	BeforeEach(func() {
-		test = newLoadTest()
+		test = testutil.NewLoadTest(1, 1)
 		namespacedName = types.NamespacedName{
 			Name:      test.Name,
 			Namespace: test.Namespace,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -42,7 +41,6 @@ import (
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/config"
-	"github.com/grpc/test-infra/optional"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -103,76 +101,6 @@ func newDefaults() *config.Defaults {
 				RunImage:   "gcr.io/grpc-fake-project/test-infra/java",
 			},
 		},
-	}
-}
-
-func newLoadTest() *grpcv1.LoadTest {
-	return &grpcv1.LoadTest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      uuid.New().String(),
-			Namespace: corev1.NamespaceDefault,
-		},
-		Spec: grpcv1.LoadTestSpec{
-			TimeoutSeconds: 300,
-			TTLSeconds:     600,
-			Driver: &grpcv1.Driver{
-				Name:     optional.StringPtr("driver"),
-				Language: "cxx",
-				Pool:     optional.StringPtr("test-pool"),
-				Run: grpcv1.Run{
-					Image: optional.StringPtr("gcr.io/grpc-test-example/driver:v1"),
-				},
-			},
-			Servers: []grpcv1.Server{
-				{
-					Name:     optional.StringPtr("server-1"),
-					Language: "go",
-					Pool:     optional.StringPtr("test-pool"),
-					Clone: &grpcv1.Clone{
-						Image:  optional.StringPtr("gcr.io/grpc-test-example/clone:v1"),
-						Repo:   optional.StringPtr("https://github.com/grpc/test-infra.git"),
-						GitRef: optional.StringPtr("master"),
-					},
-					Build: &grpcv1.Build{
-						Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
-						Command: []string{"go"},
-						Args:    []string{"build", "-o", "server", "./server/main.go"},
-					},
-					Run: grpcv1.Run{
-						Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
-						Command: []string{"./server"},
-						Args:    []string{"-verbose"},
-					},
-				},
-			},
-			Clients: []grpcv1.Client{
-				{
-					Name:     optional.StringPtr("client-1"),
-					Language: "go",
-					Pool:     optional.StringPtr("test-pool"),
-					Clone: &grpcv1.Clone{
-						Image:  optional.StringPtr("gcr.io/grpc-test-example/clone:v1"),
-						Repo:   optional.StringPtr("https://github.com/grpc/test-infra.git"),
-						GitRef: optional.StringPtr("master"),
-					},
-					Build: &grpcv1.Build{
-						Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
-						Command: []string{"go"},
-						Args:    []string{"build", "-o", "client", "./client/main.go"},
-					},
-					Run: grpcv1.Run{
-						Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
-						Command: []string{"./client"},
-						Args:    []string{"-verbose"},
-					},
-				},
-			},
-			Results: &grpcv1.Results{
-				BigQueryTable: optional.StringPtr("example-dataset.example-table"),
-			},
-			ScenariosJSON: "{\"scenarios\": []}",
-		},
-		Status: grpcv1.LoadTestStatus{},
 	}
 }
 

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grpc/test-infra/config"
 	"github.com/grpc/test-infra/kubehelpers"
 	"github.com/grpc/test-infra/optional"
+	"github.com/grpc/test-infra/testutil"
 )
 
 // getNames accepts a slice of objects with a Name field. It returns the names
@@ -75,7 +76,7 @@ var _ = Describe("PodBuilder", func() {
 	var builder *PodBuilder
 
 	BeforeEach(func() {
-		test = newLoadTest()
+		test = testutil.NewLoadTest(1, 1)
 		testSpec = &test.Spec
 		defaults = newDefaults()
 		builder = New(defaults, test)

--- a/podbuilder/suite_test.go
+++ b/podbuilder/suite_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
-	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/config"
 	// +kubebuilder:scaffold:imports
 )
@@ -101,102 +100,6 @@ func newDefaults() *config.Defaults {
 				BuildImage: "java:jdk8",
 				RunImage:   "gcr.io/grpc-fake-project/test-infra/java",
 			},
-		},
-	}
-}
-
-func newLoadTest() *grpcv1.LoadTest {
-	cloneImage := "docker.pkg.github.com/grpc/test-infra/clone"
-	cloneRepo := "https://github.com/grpc/grpc.git"
-	cloneGitRef := "master"
-
-	buildImage := "l.gcr.io/google/bazel:latest"
-	buildCommand := []string{"bazel"}
-	buildArgs := []string{"build", "//test/cpp/qps:qps_worker"}
-
-	driverImage := "docker.pkg.github.com/grpc/test-infra/driver"
-	runImage := "docker.pkg.github.com/grpc/test-infra/cxx"
-	runCommand := []string{"bazel-bin/test/cpp/qps/qps_worker"}
-
-	clientRunArgs := []string{"--driver_port=10000"}
-	serverRunArgs := append(clientRunArgs, "--server_port=10010")
-
-	bigQueryTable := "grpc-testing.e2e_benchmark.foobarbuzz"
-
-	driverPool := "drivers"
-	workerPool := "workers-8core"
-
-	clientComponentName := "client-1"
-	serverComponentName := "server-1"
-	driverComponentName := "driver-1"
-
-	return &grpcv1.LoadTest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-loadtest",
-			Namespace: "default",
-		},
-
-		Spec: grpcv1.LoadTestSpec{
-			Driver: &grpcv1.Driver{
-				Name:     &driverComponentName,
-				Language: "cxx",
-				Pool:     &driverPool,
-				Run: grpcv1.Run{
-					Image: &driverImage,
-				},
-			},
-
-			Servers: []grpcv1.Server{
-				{
-					Name:     &serverComponentName,
-					Language: "cxx",
-					Pool:     &workerPool,
-					Clone: &grpcv1.Clone{
-						Image:  &cloneImage,
-						Repo:   &cloneRepo,
-						GitRef: &cloneGitRef,
-					},
-					Build: &grpcv1.Build{
-						Image:   &buildImage,
-						Command: buildCommand,
-						Args:    buildArgs,
-					},
-					Run: grpcv1.Run{
-						Image:   &runImage,
-						Command: runCommand,
-						Args:    serverRunArgs,
-					},
-				},
-			},
-
-			Clients: []grpcv1.Client{
-				{
-					Name:     &clientComponentName,
-					Language: "cxx",
-					Pool:     &workerPool,
-					Clone: &grpcv1.Clone{
-						Image:  &cloneImage,
-						Repo:   &cloneRepo,
-						GitRef: &cloneGitRef,
-					},
-					Build: &grpcv1.Build{
-						Image:   &buildImage,
-						Command: buildCommand,
-						Args:    buildArgs,
-					},
-					Run: grpcv1.Run{
-						Image:   &runImage,
-						Command: runCommand,
-						Args:    clientRunArgs,
-					},
-				},
-			},
-
-			Results: &grpcv1.Results{
-				BigQueryTable: &bigQueryTable,
-			},
-
-			ScenariosJSON: "{\"scenarios\": []}",
 		},
 	}
 }

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -16,16 +16,17 @@ limitations under the License.
 package status
 
 import (
-	grpcv1 "github.com/grpc/test-infra/api/v1"
-	"github.com/grpc/test-infra/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+	"github.com/grpc/test-infra/config"
 )
 
 var _ = Describe("CheckMissingPods", func() {
-
 	var test *grpcv1.LoadTest
 	var allRunningPods []*corev1.Pod
 	var actualReturn *LoadTestMissing
@@ -57,7 +58,6 @@ var _ = Describe("CheckMissingPods", func() {
 	})
 
 	Context("some of pods from the current load test is running", func() {
-
 		BeforeEach(func() {
 			allRunningPods = append(allRunningPods,
 				&corev1.Pod{
@@ -114,7 +114,6 @@ var _ = Describe("CheckMissingPods", func() {
 	})
 
 	Context("all of pods from the current load test is running", func() {
-
 		BeforeEach(func() {
 			allRunningPods = populatePodListWithCurrentLoadTestPod(test)
 		})

--- a/testutil/loadtest_factory.go
+++ b/testutil/loadtest_factory.go
@@ -1,0 +1,90 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+	"github.com/grpc/test-infra/optional"
+)
+
+// NewLoadTest creates a LoadTest instance for unit and e2e tests. It accepts
+// the number of servers and clients that should be included in the test. Each
+// server and client will have the word "server-" or "client-" as a prefix and
+// an incrementing number as the suffix. For example, 3 servers will have the
+// names: "server-1", "server-2" and "server-3".
+func NewLoadTest(serverCount, clientCount int) *grpcv1.LoadTest {
+	test := &grpcv1.LoadTest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uuid.New().String(),
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: grpcv1.LoadTestSpec{
+			TimeoutSeconds: 300,
+			TTLSeconds:     600,
+			Driver: &grpcv1.Driver{
+				Name:     optional.StringPtr("driver"),
+				Language: "cxx",
+				Pool:     optional.StringPtr("test-pool"),
+				Run: grpcv1.Run{
+					Image: optional.StringPtr("gcr.io/grpc-test-example/driver:v1"),
+				},
+			},
+			Results: &grpcv1.Results{
+				BigQueryTable: optional.StringPtr("example-dataset.example-table"),
+			},
+			ScenariosJSON: "{\"scenarios\": []}",
+		},
+	}
+
+	for i := 1; i <= serverCount; i++ {
+		test.Spec.Servers = append(test.Spec.Servers, grpcv1.Server{
+			Name:     optional.StringPtr(fmt.Sprintf("server-%d", i)),
+			Language: "go",
+			Pool:     optional.StringPtr("test-pool"),
+			Clone: &grpcv1.Clone{
+				Image:  optional.StringPtr("gcr.io/grpc-test-example/clone:v1"),
+				Repo:   optional.StringPtr("https://github.com/grpc/test-infra.git"),
+				GitRef: optional.StringPtr("master"),
+			},
+			Build: &grpcv1.Build{
+				Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
+				Command: []string{"go"},
+				Args:    []string{"build", "-o", "server", "./server/main.go"},
+			},
+			Run: grpcv1.Run{
+				Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
+				Command: []string{"./server"},
+				Args:    []string{"-verbose"},
+			},
+		})
+	}
+
+	for i := 1; i <= clientCount; i++ {
+		test.Spec.Clients = append(test.Spec.Clients, grpcv1.Client{
+			Name:     optional.StringPtr(fmt.Sprintf("client-%d", i)),
+			Language: "go",
+			Pool:     optional.StringPtr("test-pool"),
+			Clone: &grpcv1.Clone{
+				Image:  optional.StringPtr("gcr.io/grpc-test-example/clone:v1"),
+				Repo:   optional.StringPtr("https://github.com/grpc/test-infra.git"),
+				GitRef: optional.StringPtr("master"),
+			},
+			Build: &grpcv1.Build{
+				Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
+				Command: []string{"go"},
+				Args:    []string{"build", "-o", "client", "./client/main.go"},
+			},
+			Run: grpcv1.Run{
+				Image:   optional.StringPtr("gcr.io/grpc-test-example/go:v1"),
+				Command: []string{"./client"},
+				Args:    []string{"-verbose"},
+			},
+		})
+	}
+
+	return test
+}


### PR DESCRIPTION
This draft change adds a testutil package with a NewLoadTest function in order to share logic across test suites. It will also transition all test suites to use this shared package.