### PR TITLE
Gang Scheduling

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -372,6 +372,10 @@ var ConfigurationError = "ConfigurationError"
 // in the Initializing state.
 var PodsMissing = "PodsMissing"
 
+// PoolError is the reason string when a driver, client or server requires nodes
+// from a nonexistent pool.
+var PoolError = "PoolError"
+
 // TimeoutErrored is the reason string when the load test has not yet terminated
 // but exceeded the timeout.
 var TimeoutErrored = "TimeoutErrored"

--- a/config/constants.go
+++ b/config/constants.go
@@ -66,6 +66,10 @@ const (
 	// LoadTestLabel is a label which contains the test's unique name.
 	LoadTestLabel = "loadtest"
 
+	// PoolLabel is the key for a label which will have the name of a pool as
+	// the value.
+	PoolLabel = "pool"
+
 	// ReadyInitContainerName holds the name of the init container that blocks a
 	// driver from running until all worker pods are ready.
 	ReadyInitContainerName = "ready"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -36,9 +37,15 @@ import (
 	"github.com/grpc/test-infra/status"
 )
 
+var (
+	errCacheSync       = errors.New("failed to sync cache")
+	errNonexistentPool = errors.New("pool does not exist")
+)
+
 // LoadTestReconciler reconciles a LoadTest object
 type LoadTestReconciler struct {
 	client.Client
+	mgr      ctrl.Manager
 	Defaults *config.Defaults
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
@@ -50,6 +57,8 @@ type LoadTestReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get
 
 // Reconcile attempts to bring the current state of the load test into agreement
 // with its declared spec. This may mean provisioning resources, doing nothing
@@ -99,11 +108,9 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		test.Status.State = grpcv1.Errored
 		test.Status.Reason = grpcv1.FailedSettingDefaultsError
 		test.Status.Message = fmt.Sprintf("failed to reconcile tests with defaults: %v", err)
-
 		if err = r.Status().Update(ctx, test); err != nil {
 			log.Error(err, "failed to update test status when setting defaults failed")
 		}
-
 		return ctrl.Result{}, err
 	}
 	if !reflect.DeepEqual(rawTest, test) {
@@ -121,15 +128,12 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// The ConfigMap existence was not at issue, so this is likely an
 			// issue with the Kubernetes API. So, we'll update the status, retry
 			// with exponential backoff and allow the timeout to catch it.
-
 			test.Status.State = grpcv1.Unknown
 			test.Status.Reason = grpcv1.KubernetesError
 			test.Status.Message = fmt.Sprintf("kubernetes error (retrying): failed to get scenarios ConfigMap: %v", err)
-
 			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
 				log.Error(updateErr, "failed to update status after failure to get scenarios ConfigMap: %v", err)
 			}
-
 			return ctrl.Result{}, err
 		}
 
@@ -152,15 +156,12 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// for manual cleanup, it could create hidden errors when a load
 			// test with the same name is created.
 			log.Error(refError, "could not set controller reference on scenarios ConfigMap")
-
 			test.Status.State = grpcv1.Unknown
 			test.Status.Reason = grpcv1.KubernetesError
 			test.Status.Message = fmt.Sprintf("kubernetes error (retrying): could not setup garbage collection for scenarios ConfigMap: %v", refError)
-
 			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
 				log.Error(updateErr, "failed to update status after failure to get and create scenarios ConfigMap")
 			}
-
 			return ctrl.Result{Requeue: true}, refError
 		}
 
@@ -175,131 +176,221 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		log.Error(err, "failed to list pods", "namespace", req.Namespace)
 		return ctrl.Result{Requeue: true}, err
 	}
-
 	ownedPods := status.PodsForLoadTest(test, pods.Items)
 
 	previousStatus := test.Status
 	test.Status = status.ForLoadTest(test, ownedPods)
-
 	if err = r.Status().Update(ctx, test); err != nil {
 		log.Error(err, "failed to update test status")
 		return ctrl.Result{Requeue: true}, err
 	}
 
 	missingPods := status.CheckMissingPods(test, ownedPods)
-	builder := podbuilder.New(r.Defaults, test)
-
-	createPod := func(pod *corev1.Pod) (*ctrl.Result, error) {
-		if err = ctrl.SetControllerReference(test, pod, r.Scheme); err != nil {
-			log.Error(err, "could not set controller reference on pod, pod will not be garbage collected", "pod", pod)
-			return &ctrl.Result{}, err
+	if !missingPods.IsEmpty() {
+		if !r.mgr.GetCache().WaitForCacheSync(ctx.Done()) {
+			log.Error(errCacheSync, "could not invalidate the cache which is required to gang schedule")
+			return ctrl.Result{Requeue: true}, errCacheSync
 		}
 
-		if err = r.Create(ctx, pod); err != nil {
-			log.Error(err, "could not create new pod", "pod", pod)
-			return &ctrl.Result{Requeue: true}, err
+		nodes := new(corev1.NodeList)
+		if err = r.List(ctx, nodes); err != nil {
+			log.Error(err, "failed to list nodes")
+			return ctrl.Result{Requeue: true}, err
 		}
 
-		return nil, nil
-	}
-
-	for i := range missingPods.Servers {
-		logWithServer := log.WithValues("server", missingPods.Servers[i])
-
-		pod, err := builder.PodForServer(&missingPods.Servers[i])
-		if err != nil {
-			logWithServer.Error(err, "failed to construct a pod struct for supplied server struct")
-
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.ConfigurationError
-			test.Status.Message = fmt.Sprintf("failed to construct a pod for server at index %d: %v", i, err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithServer.Error(updateErr, "failed to update status after failure to construct a pod for server")
+		var defaultClientPool string
+		var defaultDriverPool string
+		var defaultServerPool string
+		poolCapacities := make(map[string]int)
+		for _, node := range nodes.Items {
+			pool, ok := node.Labels[config.PoolLabel]
+			if !ok {
+				log.Info("encountered a node without a pool label", "nodeName", node.Name)
+				continue
 			}
 
-			return ctrl.Result{}, err
-		}
+			if defaultPoolLabels := r.Defaults.DefaultPoolLabels; defaultPoolLabels != nil {
+				if defaultClientPool == "" {
+					if _, ok := node.Labels[defaultPoolLabels.Client]; ok {
+						defaultClientPool = pool
+					}
+				}
+				if defaultDriverPool == "" {
+					if _, ok := node.Labels[defaultPoolLabels.Driver]; ok {
+						defaultDriverPool = pool
+					}
+				}
+				if defaultServerPool == "" {
+					if _, ok := node.Labels[defaultPoolLabels.Server]; ok {
+						defaultServerPool = pool
+					}
+				}
 
-		result, err := createPod(pod)
-		if result != nil && !kerrors.IsAlreadyExists(err) {
-			logWithServer.Error(err, "failed to create pod for server")
-
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.KubernetesError
-			test.Status.Message = fmt.Sprintf("failed to create pod for server at index %d: %v", i, err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithServer.Error(updateErr, "failed to update status after failure to create pod for server")
+				if _, ok = poolCapacities[pool]; !ok {
+					poolCapacities[pool] = 0
+				}
 			}
 
-			return *result, err
-		}
-	}
-	for i := range missingPods.Clients {
-		logWithClient := log.WithValues("client", missingPods.Clients[i])
-
-		pod, err := builder.PodForClient(&missingPods.Clients[i])
-		if err != nil {
-			logWithClient.Error(err, "failed to construct a pod struct for supplied client struct")
-
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.ConfigurationError
-			test.Status.Message = fmt.Sprintf("failed to construct a pod for client at index %d: %v", i, err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithClient.Error(updateErr, "failed to update status after failure to construct a pod for client")
-			}
-
-			return ctrl.Result{}, err
+			poolCapacities[pool]++
 		}
 
-		result, err := createPod(pod)
-		if result != nil && !kerrors.IsAlreadyExists(err) {
-			logWithClient.Error(err, "failed to create pod for client")
-
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.KubernetesError
-			test.Status.Message = fmt.Sprintf("failed to create pod for client at index %d: %v", i, err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithClient.Error(updateErr, "failed to update status after failure to create pod for client")
-			}
-
-			return *result, err
+		poolAvailabilities := make(map[string]int)
+		for pool, capacity := range poolCapacities {
+			poolAvailabilities[pool] = capacity
 		}
-	}
-	if missingPods.Driver != nil {
-		logWithDriver := log.WithValues("driver", missingPods.Driver)
-
-		pod, err := builder.PodForDriver(missingPods.Driver)
-		if err != nil {
-			logWithDriver.Error(err, "failed to construct a pod struct for supplied driver struct")
-
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.ConfigurationError
-			test.Status.Message = fmt.Sprintf("failed to construct a pod for driver: %v", err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithDriver.Error(updateErr, "failed to update status after failure to construct a pod for driver")
+		for _, pod := range pods.Items {
+			pool, ok := pod.Labels[config.PoolLabel]
+			if !ok {
+				log.Info("encountered a pod without a pool label", "pod", pod)
+				continue
 			}
-
-			return ctrl.Result{}, err
+			if pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+				poolAvailabilities[pool]--
+			}
 		}
 
-		result, err := createPod(pod)
-		if result != nil && !kerrors.IsAlreadyExists(err) {
-			logWithDriver.Error(err, "failed to create pod for driver")
+		adjustAvailabilityForDefaults := func(defaultPoolKey, defaultPoolName string) {
+			if c, ok := missingPods.NodeCountByPool[defaultPoolKey]; ok {
+				missingPods.NodeCountByPool[defaultPoolName] += c
+			}
+			delete(missingPods.NodeCountByPool, defaultPoolKey)
+		}
+		adjustAvailabilityForDefaults(status.DefaultClientPool, defaultClientPool)
+		adjustAvailabilityForDefaults(status.DefaultDriverPool, defaultDriverPool)
+		adjustAvailabilityForDefaults(status.DefaultServerPool, defaultServerPool)
 
-			test.Status.State = grpcv1.Errored
-			test.Status.Reason = grpcv1.KubernetesError
-			test.Status.Message = fmt.Sprintf("failed to create pod for driver: %v", err)
-
-			if updateErr := r.Status().Update(ctx, test); updateErr != nil {
-				logWithDriver.Error(updateErr, "failed to update status after failure to create pod for driver")
+		for pool, requiredNodeCount := range missingPods.NodeCountByPool {
+			availableNodeCount, ok := poolAvailabilities[pool]
+			if !ok {
+				log.Error(errNonexistentPool, "requested pool does not exist and cannot be considered when scheduling", "requestedPool", pool)
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.PoolError
+				test.Status.Message = fmt.Sprintf("requested pool %q does not exist", pool)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					log.Error(updateErr, "failed to update status after failure due to requesting nodes from a nonexistent pool")
+				}
+				return ctrl.Result{}, errNonexistentPool
 			}
 
-			return *result, err
+			if requiredNodeCount > availableNodeCount {
+				log.Info("cannot schedule test: inadequate availability for pool", "pool", pool, "requiredNodeCount", requiredNodeCount, "availableNodeCount", availableNodeCount)
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+		}
+
+		builder := podbuilder.New(r.Defaults, test)
+		createPod := func(pod *corev1.Pod) (*ctrl.Result, error) {
+			if err = ctrl.SetControllerReference(test, pod, r.Scheme); err != nil {
+				log.Error(err, "could not set controller reference on pod, pod will not be garbage collected", "pod", pod)
+				return &ctrl.Result{}, err
+			}
+
+			if err = r.Create(ctx, pod); err != nil {
+				log.Error(err, "could not create new pod", "pod", pod)
+				return &ctrl.Result{Requeue: true}, err
+			}
+
+			return nil, nil
+		}
+
+		for i := range missingPods.Servers {
+			logWithServer := log.WithValues("server", missingPods.Servers[i])
+
+			pod, err := builder.PodForServer(&missingPods.Servers[i])
+			if err != nil {
+				logWithServer.Error(err, "failed to construct a pod struct for supplied server struct")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.ConfigurationError
+				test.Status.Message = fmt.Sprintf("failed to construct a pod for server at index %d: %v", i, err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithServer.Error(updateErr, "failed to update status after failure to construct a pod for server")
+				}
+				return ctrl.Result{}, err
+			}
+
+			if missingPods.Servers[i].Pool == nil {
+				pod.Labels[config.PoolLabel] = defaultServerPool
+			} else {
+				pod.Labels[config.PoolLabel] = *missingPods.Servers[i].Pool
+			}
+
+			result, err := createPod(pod)
+			if result != nil && !kerrors.IsAlreadyExists(err) {
+				logWithServer.Error(err, "failed to create pod for server")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.KubernetesError
+				test.Status.Message = fmt.Sprintf("failed to create pod for server at index %d: %v", i, err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithServer.Error(updateErr, "failed to update status after failure to create pod for server")
+				}
+				return *result, err
+			}
+		}
+		for i := range missingPods.Clients {
+			logWithClient := log.WithValues("client", missingPods.Clients[i])
+
+			pod, err := builder.PodForClient(&missingPods.Clients[i])
+			if err != nil {
+				logWithClient.Error(err, "failed to construct a pod struct for supplied client struct")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.ConfigurationError
+				test.Status.Message = fmt.Sprintf("failed to construct a pod for client at index %d: %v", i, err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithClient.Error(updateErr, "failed to update status after failure to construct a pod for client")
+				}
+				return ctrl.Result{}, err
+			}
+
+			if missingPods.Clients[i].Pool == nil {
+				pod.Labels[config.PoolLabel] = defaultClientPool
+			} else {
+				pod.Labels[config.PoolLabel] = *missingPods.Clients[i].Pool
+			}
+
+			result, err := createPod(pod)
+			if result != nil && !kerrors.IsAlreadyExists(err) {
+				logWithClient.Error(err, "failed to create pod for client")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.KubernetesError
+				test.Status.Message = fmt.Sprintf("failed to create pod for client at index %d: %v", i, err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithClient.Error(updateErr, "failed to update status after failure to create pod for client")
+				}
+				return *result, err
+			}
+		}
+		if missingPods.Driver != nil {
+			logWithDriver := log.WithValues("driver", missingPods.Driver)
+
+			pod, err := builder.PodForDriver(missingPods.Driver)
+			if err != nil {
+				logWithDriver.Error(err, "failed to construct a pod struct for supplied driver struct")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.ConfigurationError
+				test.Status.Message = fmt.Sprintf("failed to construct a pod for driver: %v", err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithDriver.Error(updateErr, "failed to update status after failure to construct a pod for driver")
+				}
+				return ctrl.Result{}, err
+			}
+
+			if missingPods.Driver.Pool == nil {
+				pod.Labels[config.PoolLabel] = defaultDriverPool
+			} else {
+				pod.Labels[config.PoolLabel] = *missingPods.Driver.Pool
+			}
+
+			result, err := createPod(pod)
+			if result != nil && !kerrors.IsAlreadyExists(err) {
+				logWithDriver.Error(err, "failed to create pod for driver")
+				test.Status.State = grpcv1.Errored
+				test.Status.Reason = grpcv1.KubernetesError
+				test.Status.Message = fmt.Sprintf("failed to create pod for driver: %v", err)
+				if updateErr := r.Status().Update(ctx, test); updateErr != nil {
+					logWithDriver.Error(updateErr, "failed to update status after failure to create pod for driver")
+				}
+				return *result, err
+			}
 		}
 	}
 
@@ -338,6 +429,7 @@ func getRequeueTime(updatedLoadTest *grpcv1.LoadTest, previousStatus grpcv1.Load
 
 // SetupWithManager configures a controller-runtime manager.
 func (r *LoadTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.mgr = mgr
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&grpcv1.LoadTest{}).
 		Owns(&corev1.Pod{}).

--- a/status/missing_pods.go
+++ b/status/missing_pods.go
@@ -22,19 +22,50 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// DefaultClientPool is a key in the NodeCountByPool map on the LoadTestMissing
+// struct. It maps to the number of nodes required from the default client pool.
+const DefaultClientPool = "__default_pool (clients)"
+
+// DefaultDriverPool is a key in the NodeCountByPool map on the LoadTestMissing
+// struct. It maps to the number of nodes required from the default driver pool.
+const DefaultDriverPool = "__default_pool (drivers)"
+
+// DefaultServerPool is a key in the NodeCountByPool map on the LoadTestMissing
+// struct. It maps to the number of nodes required from the default server pool.
+const DefaultServerPool = "__default_pool (servers)"
+
 // LoadTestMissing defines missing pods of LoadTest.
 type LoadTestMissing struct {
 	// Driver is the component that orchestrates the test. If Driver is not set
 	// that means we already have the Driver running.
-	Driver *grpcv1.Driver `json:"driver,omitempty"`
+	Driver *grpcv1.Driver
 
 	// Servers are a list of components that receive traffic from. The list
 	// indicates the Servers still in need.
-	Servers []grpcv1.Server `json:"servers,omitempty"`
+	Servers []grpcv1.Server
 
 	// Clients are a list of components that send traffic to servers. The list
 	// indicates the Clients still in need.
-	Clients []grpcv1.Client `json:"clients,omitempty"`
+	Clients []grpcv1.Client
+
+	// NodeCountPyPool is a map which gives the number of nodes required from
+	// each pool to run the test. These counts will not include any pods from
+	// the test that have already been scheduled. The names of the required node
+	// pools are the keys and the value is the number of nodes required from the
+	// named pool.
+	//
+	// If a test does not require any nodes from a pool, the pool name will not
+	// be present as a key in the map. If a driver, client or server has not
+	// been scheduled for a test and does not specify a pool, it will be counted
+	// in one of the default pool keys. See the DefaultClientPool,
+	// DefaultDriverPool and DefaultServerPool constants.
+	NodeCountByPool map[string]int
+}
+
+// IsEmpty returns true if there are no missing driver, servers or clients on a
+// LoadTestMissing struct. Otherwise, it returns false.
+func (ltm *LoadTestMissing) IsEmpty() bool {
+	return ltm.Driver == nil && len(ltm.Servers) == 0 && len(ltm.Clients) == 0
 }
 
 // CheckMissingPods attempts to check if any required component is missing from
@@ -42,8 +73,15 @@ type LoadTestMissing struct {
 // list that contains all running pods at the moment, returning all missing
 // components required from the current load test with their roles.
 func CheckMissingPods(test *grpcv1.LoadTest, ownedPods []*corev1.Pod) *LoadTestMissing {
-
-	currentMissing := &LoadTestMissing{Servers: []grpcv1.Server{}, Clients: []grpcv1.Client{}}
+	currentMissing := &LoadTestMissing{
+		Servers: []grpcv1.Server{},
+		Clients: []grpcv1.Client{},
+		NodeCountByPool: map[string]int{
+			DefaultClientPool: 0,
+			DefaultDriverPool: 0,
+			DefaultServerPool: 0,
+		},
+	}
 
 	requiredClientMap := make(map[string]*grpcv1.Client)
 	requiredServerMap := make(map[string]*grpcv1.Server)
@@ -83,16 +121,38 @@ func CheckMissingPods(test *grpcv1.LoadTest, ownedPods []*corev1.Pod) *LoadTestM
 		}
 	}
 
+	incNodeCount := func(pool string) {
+		if _, ok := currentMissing.NodeCountByPool[pool]; !ok {
+			currentMissing.NodeCountByPool[pool] = 0
+		}
+		currentMissing.NodeCountByPool[pool]++
+	}
+
 	for _, eachMissingClient := range requiredClientMap {
 		currentMissing.Clients = append(currentMissing.Clients, *eachMissingClient)
+		if eachMissingClient.Pool == nil {
+			currentMissing.NodeCountByPool[DefaultClientPool]++
+		} else {
+			incNodeCount(*eachMissingClient.Pool)
+		}
 	}
 
 	for _, eachMissingServer := range requiredServerMap {
 		currentMissing.Servers = append(currentMissing.Servers, *eachMissingServer)
+		if eachMissingServer.Pool == nil {
+			currentMissing.NodeCountByPool[DefaultServerPool]++
+		} else {
+			incNodeCount(*eachMissingServer.Pool)
+		}
 	}
 
 	if !foundDriver {
 		currentMissing.Driver = test.Spec.Driver
+		if test.Spec.Driver.Pool == nil {
+			currentMissing.NodeCountByPool[DefaultDriverPool]++
+		} else {
+			incNodeCount(*test.Spec.Driver.Pool)
+		}
 	}
 
 	return currentMissing

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -54,10 +54,22 @@ var _ = Describe("CheckMissingPods", func() {
 			Expect(actualReturn.Servers).To(ConsistOf(expectedReturn.Servers))
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))
 		})
+
+		It("sets the number of nodes missing from each pool", func() {
+			actualReturn = CheckMissingPods(test, allRunningPods)
+			Expect(actualReturn.NodeCountByPool).To(Equal(
+				map[string]int{
+					"drivers":         1,
+					"workers":         6,
+					DefaultClientPool: 0,
+					DefaultDriverPool: 0,
+					DefaultServerPool: 0,
+				},
+			))
+		})
 	})
 
 	Context("some of pods from the current load test is running", func() {
-
 		BeforeEach(func() {
 			allRunningPods = append(allRunningPods,
 				&corev1.Pod{
@@ -111,10 +123,20 @@ var _ = Describe("CheckMissingPods", func() {
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))
 		})
 
+		It("sets the number of nodes missing from each pool", func() {
+			actualReturn = CheckMissingPods(test, allRunningPods)
+			Expect(actualReturn.NodeCountByPool).To(Equal(
+				map[string]int{
+					"workers":         4,
+					DefaultClientPool: 0,
+					DefaultDriverPool: 0,
+					DefaultServerPool: 0,
+				},
+			))
+		})
 	})
 
 	Context("all of pods from the current load test is running", func() {
-
 		BeforeEach(func() {
 			allRunningPods = populatePodListWithCurrentLoadTestPod(test)
 		})
@@ -124,6 +146,17 @@ var _ = Describe("CheckMissingPods", func() {
 			Expect(actualReturn.Clients).To(ConsistOf(expectedReturn.Clients))
 			Expect(actualReturn.Servers).To(ConsistOf(expectedReturn.Servers))
 			Expect(actualReturn.Driver).To(Equal(expectedReturn.Driver))
+		})
+
+		It("sets the number of nodes missing from each pool", func() {
+			actualReturn = CheckMissingPods(test, allRunningPods)
+			Expect(actualReturn.NodeCountByPool).To(Equal(
+				map[string]int{
+					DefaultClientPool: 0,
+					DefaultDriverPool: 0,
+					DefaultServerPool: 0,
+				},
+			))
 		})
 	})
 })

--- a/status/suite_test.go
+++ b/status/suite_test.go
@@ -53,7 +53,7 @@ func newLoadTestWithMultipleClientsAndServers() *grpcv1.LoadTest {
 	bigQueryTable := "grpc-testing.e2e_benchmark.foobarbuzz"
 
 	driverPool := "drivers"
-	workerPool := "workers-8core"
+	workerPool := "workers"
 
 	driverComponentName := "driver-1"
 


### PR DESCRIPTION
The default Kubernetes scheduler considers each pod individually when scheduling. The only relationships it understands between pods are constraints regarding coexistence on nodes. Unfortunately, this is not sufficient for gRPC load tests. Client pods require server pods in order to send traffic. Both client pods and server pods require a driver pod in order to receive their instructions. Therefore, all of a test's pods must be alive on the cluster for the test to start and complete.

The number of tests that can run is limited by the number of nodes available in the pools the test requires. If a node becomes available for a pod, the default scheduler will immediately schedule it without regard to whether the other pods required for the test are scheduled. This has led to a starvation problem where the cluster becomes filled with some but not all pods required for any test to complete.

Requiring the scheduler to assign related pods to nodes together is referred to as gang scheduling. It is not implemented in Kubernetes. This commit implements a naive gang scheduling system by delaying the creation of a pod for a load test when the cluster cannot accommodate all of the load test's pods.

This pull request adds support for gang scheduling. Gang scheduling means that the load test is considered as an atomic unit when making a decision to schedule any of its pods. If the cluster's current node availability cannot accommodate all of the test's pods, the controller will now defer scheduling any of them. When nodes become available to accommodate all of the test's pods, all pods are scheduled at the same time.

Note this pull request diverges from best practice for a custom Kubernetes controller. Scheduling logic does not belong in a controller. However, the Kubernetes scheduler is complex and has many factors that are considered when making scheduling decisions. Implementing a naive alternative scheduler would be costly. In addition, a controller is expected to be level-driven and operate with a cache. Scheduling decisions require a current view of the cluster; therefore, these changes manually invalidate the cache. This create/delay approach is a compromise due to the current limitations of Kubernetes.