### PR TITLE
Fix status updates when duplicate pods are created

### DIFF
--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -221,7 +222,7 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 
 		result, err := createPod(pod)
-		if result != nil {
+		if result != nil && !kerrors.IsAlreadyExists(err) {
 			logWithServer.Error(err, "failed to create pod for server")
 
 			test.Status.State = grpcv1.Errored
@@ -254,7 +255,7 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 
 		result, err := createPod(pod)
-		if result != nil {
+		if result != nil && !kerrors.IsAlreadyExists(err) {
 			logWithClient.Error(err, "failed to create pod for client")
 
 			test.Status.State = grpcv1.Errored
@@ -287,7 +288,7 @@ func (r *LoadTestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 
 		result, err := createPod(pod)
-		if result != nil {
+		if result != nil && !kerrors.IsAlreadyExists(err) {
 			logWithDriver.Error(err, "failed to create pod for driver")
 
 			test.Status.State = grpcv1.Errored


### PR DESCRIPTION
Controllers are level-driven and operate with a cache, meaning invocations of the Reconcile method on the LoadTestReconciler may not always be able to access up-to-date information. When many invocations occur in a short timespan, the cache may not reflect the actual state of the cluster. Since a newly created pod may not be immediately noticed via the cache, multiple pod creation attempts may occur.

Previously, multiple attempts to create a pod resulted in a Kubernetes error. The test was considered to have errored. However, often the pods were created successfully and there was no mechanism to stop the test. The test could be marked as an error but continue to run successfully.

This change adds checks to prevent test errors when the controller attempts to create a duplicate pod.