### PR TITLE
Update image name for csharp build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,11 @@ push-python-image:
 	docker push ${IMAGE_PREFIX}python:${TEST_INFRA_VERSION}
 
 # Build the csharp build image
-csharp-image:
+csharp-build-image:
 	docker build -t ${BUILD_IMAGE_PREFIX}csharp:${TEST_INFRA_VERSION} containers/init/build/csharp
 
 # Push the csharp build image to a docker registry
-push-csharp-image:
+push-csharp-build-image:
 	docker push ${BUILD_IMAGE_PREFIX}csharp:${TEST_INFRA_VERSION}
 
 # Build all init container and runtime container images
@@ -184,7 +184,7 @@ all-images: \
 	java-image \
 	ruby-image \
 	python-image \
-	csharp-image \
+	csharp-build-image \
 	controller-image\
 	cleanup-agent-image
 
@@ -198,7 +198,7 @@ push-all-images: \
 	push-java-image \
 	push-ruby-image \
 	push-python-image \
-	push-csharp-image \
+	push-csharp-build-image \
 	push-controller-image \
 	push-cleanup-agent-image
 


### PR DESCRIPTION
To support csharp tests, only customized build image is required. The build target for the csharp build image was previously named csharp-image, which did not reflect the fact that it is a build image. This commit updates the name of the build target to csharp-build-image, to better reflect its nature.