### PR TITLE
Add Kubernetes API client for LoadTest resources

### DIFF
--- a/clientset/client.go
+++ b/clientset/client.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+)
+
+// GRPCTestClientset provides methods to access custom Kubernetes clients for
+// testing gRPC.
+type GRPCTestClientset interface {
+	// LoadTestV1 returns the load test interface, which provides operations on
+	// version 1 load tests.
+	LoadTestV1() LoadTestInterface
+}
+
+type grpcTestV1 struct {
+	client rest.Interface
+}
+
+func (gv1 *grpcTestV1) LoadTestV1() LoadTestInterface {
+	return &loadTestV1{gv1.client}
+}
+
+type gRPCTestClient struct {
+	client rest.Interface
+}
+
+func (gc *gRPCTestClient) LoadTestV1() LoadTestInterface {
+	return &loadTestV1{gc.client}
+}
+
+// NewForConfig accepts a Kubernetes REST Client config and adds the appropriate
+// group, version and serializers to handle requests regarding gRPC test
+// resources.
+func NewForConfig(c *rest.Config) (GRPCTestClientset, error) {
+	config := *c
+
+	gv := grpcv1.GroupVersion
+	config.GroupVersion = &gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = serializer.NewCodecFactory(clientgoscheme.Scheme)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	client, err := rest.UnversionedRESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gRPCTestClient{client}, nil
+}

--- a/clientset/loadtest_interface.go
+++ b/clientset/loadtest_interface.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+)
+
+// LoadTestGetter specifies methods for accessing or mutating load tests.
+type LoadTestGetter interface {
+	// Create saves a new test resource.
+	Create(test *grpcv1.LoadTest, opts metav1.CreateOptions) (*grpcv1.LoadTest, error)
+
+	// Get fetches a test, given its name and any options.
+	Get(name string, opts metav1.GetOptions) (*grpcv1.LoadTest, error)
+
+	// List fetches all tests, given its options.
+	List(opts metav1.ListOptions) (*grpcv1.LoadTestList, error)
+
+	// Delete removes a new test resource, given its name.
+	Delete(name string, opts metav1.DeleteOptions) error
+}
+
+// LoadTestInterface provides methods for accessing a LoadTestGetter when given
+// a namespace.
+type LoadTestInterface interface {
+	LoadTests(namespace string) LoadTestGetter
+}

--- a/clientset/loadtest_v1.go
+++ b/clientset/loadtest_v1.go
@@ -1,0 +1,70 @@
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+)
+
+type loadTestV1Getter struct {
+	ns     string
+	client rest.Interface
+}
+
+func (l *loadTestV1Getter) Create(test *grpcv1.LoadTest, opts metav1.CreateOptions) (*grpcv1.LoadTest, error) {
+	createdTest := &grpcv1.LoadTest{}
+	err := l.client.Post().
+		Namespace(l.ns).
+		Resource("loadtests").
+		Body(test).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(createdTest)
+	return createdTest, err
+}
+
+func (l *loadTestV1Getter) Get(name string, opts metav1.GetOptions) (*grpcv1.LoadTest, error) {
+	test := &grpcv1.LoadTest{}
+	err := l.client.Get().
+		Namespace(l.ns).
+		Resource("loadtests").
+		Name(name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(test)
+	return test, err
+}
+
+func (l *loadTestV1Getter) List(opts metav1.ListOptions) (*grpcv1.LoadTestList, error) {
+	tests := &grpcv1.LoadTestList{}
+	err := l.client.Get().
+		Namespace(l.ns).
+		Resource("loadtests").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(tests)
+	return tests, err
+}
+
+func (l *loadTestV1Getter) Delete(name string, opts metav1.DeleteOptions) error {
+	return l.client.Delete().
+		Namespace(l.ns).
+		Resource("loadtests").
+		Name(name).
+		Body(&opts).
+		Do().
+		Error()
+}
+
+type loadTestV1 struct {
+	client rest.Interface
+}
+
+func (lv *loadTestV1) LoadTests(namespace string) LoadTestGetter {
+	return &loadTestV1Getter{
+		ns:     namespace,
+		client: lv.client,
+	}
+}

--- a/cmd/client_test/main.go
+++ b/cmd/client_test/main.go
@@ -1,0 +1,228 @@
+// Copyright 2020 gRPC authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// This side-effect import is required by GKE.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/google/uuid"
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+	clientset "github.com/grpc/test-infra/clientset"
+	"github.com/grpc/test-infra/optional"
+)
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
+		scheme.AddKnownTypes(grpcv1.GroupVersion,
+			&grpcv1.LoadTest{},
+			&grpcv1.LoadTestList{},
+		)
+
+		metav1.AddToGroupVersion(scheme, grpcv1.GroupVersion)
+		return nil
+	})
+	addToScheme = schemeBuilder.AddToScheme
+)
+
+func main() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		if err != rest.ErrNotInCluster {
+			log.Fatalf("failed to connect within cluster: %v", err)
+		}
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("could not find a home directory for user: %v", err)
+		}
+
+		cfgPathBuilder := &strings.Builder{}
+		cfgPathBuilder.WriteString(homeDir)
+		if homeDir[:len(homeDir)-1] != "/" {
+			cfgPathBuilder.WriteString("/")
+		}
+		cfgPathBuilder.WriteString(".kube/config")
+		cfgPath := cfgPathBuilder.String()
+
+		config, err = clientcmd.BuildConfigFromFlags("", cfgPath)
+		if err != nil {
+			log.Fatalf("failed to construct config for path %q: %v", cfgPath, err)
+		}
+	}
+
+	addToScheme(clientgoscheme.Scheme)
+	scheme := clientgoscheme.Scheme
+	types := scheme.AllKnownTypes()
+	_ = types
+
+	grpcClientset, err := clientset.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("failed to create a grpc clientset: %v", err)
+	}
+	testGetter := grpcClientset.LoadTestV1().LoadTests(corev1.NamespaceDefault)
+
+	test, err := testGetter.Create(
+		&grpcv1.LoadTest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("client-test-manual-go-example-%s", uuid.New().String()),
+				Labels: map[string]string{
+					"Language": "go",
+				},
+			},
+			Spec: grpcv1.LoadTestSpec{
+				Servers: []grpcv1.Server{
+					{
+						Language: "go",
+						Clone: &grpcv1.Clone{
+							Repo:   optional.StringPtr("https://github.com/grpc/grpc-go.git"),
+							GitRef: optional.StringPtr("master"),
+						},
+						Build: &grpcv1.Build{
+							Command: []string{"go"},
+							Args:    []string{"build", "-o", "/src/workspace/bin/worker", "./benchmark/worker"},
+						},
+						Run: grpcv1.Run{
+							Command: []string{"/src/workspace/bin/worker"},
+						},
+					},
+				},
+				Clients: []grpcv1.Client{
+					{
+						Language: "go",
+						Clone: &grpcv1.Clone{
+							Repo:   optional.StringPtr("https://github.com/grpc/grpc-go.git"),
+							GitRef: optional.StringPtr("master"),
+						},
+						Build: &grpcv1.Build{
+							Command: []string{"go"},
+							Args:    []string{"build", "-o", "/src/workspace/bin/worker", "./benchmark/worker"},
+						},
+						Run: grpcv1.Run{
+							Command: []string{"/src/workspace/bin/worker"},
+						},
+					},
+				},
+				TimeoutSeconds: 900,
+				TTLSeconds:     86400,
+				ScenariosJSON: `
+{
+	"scenarios": [
+		{
+			"name": "go_generic_sync_streaming_ping_pong_secure",
+			"warmup_seconds": 5,
+			"benchmark_seconds": 30,
+			"num_servers": 1,
+			"server_config": {
+				"async_server_threads": 1,
+				"channel_args": [
+					{
+						"str_value": "latency",
+						"name": "grpc.optimization_target"
+					}
+				],
+				"payload_config": {
+					"bytebuf_params": {
+						"resp_size": 0,
+						"req_size": 0
+					}
+				},
+				"security_params": {
+					"server_host_override": "foo.test.google.fr",
+					"use_test_ca": true
+				},
+				"server_processes": 0,
+				"server_type": "ASYNC_GENERIC_SERVER",
+				"threads_per_cq": 0
+			},
+			"num_clients": 1,
+			"client_config": {
+				"async_client_threads": 1,
+				"channel_args": [
+					{
+						"name": "grpc.optimization_target",
+						"str_value": "latency"
+					}
+				],
+				"client_channels": 1,
+				"client_processes": 0,
+				"client_type": "SYNC_CLIENT",
+				"histogram_params": {
+					"max_possible": 60000000000,
+					"resolution": 0.01
+				},
+				"load_params": {
+					"closed_loop": {}
+				},
+				"outstanding_rpcs_per_channel": 1,
+				"payload_config": {
+					"bytebuf_params": {
+						"req_size": 0,
+						"resp_size": 0
+					}
+				},
+				"rpc_type": "STREAMING",
+				"security_params": {
+					"server_host_override": "foo.test.google.fr",
+					"use_test_ca": true
+				},
+				"threads_per_cq": 0
+			},
+		}
+	]
+}`,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+
+	_, err = testGetter.Get(test.Name, metav1.GetOptions{})
+	if err != nil {
+		log.Fatalf("failed to fetch the newly created test: %v", err)
+	}
+
+	testList, err := testGetter.List(metav1.ListOptions{})
+	if err != nil {
+		log.Fatalf("failed to list tests using client: %v", err)
+	}
+	found := false
+	for _, t := range testList.Items {
+		if t.Name == test.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		log.Fatalf("failed to find newly created test in list: %v", err)
+	}
+
+	err = testGetter.Delete(test.Name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Fatalf("failed to delete newly-created test using client: %v", err)
+	}
+}


### PR DESCRIPTION
This pull request introduces an API client for interacting with LoadTests, like those found in the Kubernetes client-go library. Right now, it is only a proof-of-concept.