### PR TITLE
Modify cxx image to start the start_port_server.py first

### DIFF
--- a/config/samples/cxx_example_loadtest.yaml
+++ b/config/samples/cxx_example_loadtest.yaml
@@ -29,7 +29,9 @@ spec:
         command: ["bazel"]
         args: ["build", "//test/cpp/qps:qps_worker"]
       run:
-        command: ["bazel-bin/test/cpp/qps/qps_worker"]
+        image: gcr.io/grpc-testing/wanlin/runtime/cxx
+        #command: ["bazel-bin/test/cpp/qps/qps_worker"]
+        command : ["bash", "/run_scripts/run_worker.sh"]
 
   # Users can specify multiple clients. They are bound by the
   # number of nodes.
@@ -42,7 +44,9 @@ spec:
         command: ["bazel"]
         args: ["build", "//test/cpp/qps:qps_worker"]
       run:
-        command: ["bazel-bin/test/cpp/qps/qps_worker"]
+        image: gcr.io/grpc-testing/wanlin/runtime/cxx
+        #command: ["bazel-bin/test/cpp/qps/qps_worker"]
+        command : ["bash", "/run_scripts/run_worker.sh"]
 
   # We can optionally specify where to place the results. The
   # controller will attempt to mount a service account in the driver.

--- a/containers/runtime/cxx/run_worker.sh
+++ b/containers/runtime/cxx/run_worker.sh
@@ -12,23 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3
+set -ex
 
-RUN mkdir -p /src/workspace
-WORKDIR /src/workspace
+pip3 install six
 
-RUN apt-get update && apt-get install -y \
-  autoconf \
-  build-essential \
-  clang \
-  git \
-  make \
-  libtool \
-  libgflags-dev \
-  pkg-config && \
-  apt-get clean
+python3 /src/workspace/tools/run_tests/start_port_server.py
 
-RUN mkdir /run_scripts
-ADD run_worker.sh /run_scripts
-
-CMD ["bash"]
+bazel-bin/test/cpp/qps/qps_worker

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 gRPC authors
+exi# Copyright 2020 gRPC authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit adds a script to start start_port_server.py first,
this step is to allocate ports used during the test.