### PR TITLE
Add server port flag and explanation to example

### DIFF
--- a/config/samples/cxx_example_loadtest.yaml
+++ b/config/samples/cxx_example_loadtest.yaml
@@ -30,6 +30,10 @@ spec:
         args: ["build", "//test/cpp/qps:qps_worker"]
       run:
         command: ["bazel-bin/test/cpp/qps/qps_worker"]
+        # For C++, we must specify a --server_port flag for now. This
+        # requirement exists, because there are problems with the
+        # port server in grpc/grpc running on Docker.
+        args: ["--server_port=10010"]
 
   # Users can specify multiple clients. They are bound by the
   # number of nodes.


### PR DESCRIPTION
The C++ workers in grpc/grpc rely on a server to find available ports when no explicit port is given. Unfortunately, this script relies on Python's subprocess package. The subprocess package has some compatibility issues with Docker, creating an issue where the port server could not start.

To temporarily resolve this problem, this commit explicitly introduces a --server_port flag in the run section of the server for the C++ example LoadTest YAML file. Specifying this flag disables the need for a port server, bypassing the problematic code.