### PR TITLE
Add ARG ready container's Dockerfile

### DIFF
--- a/containers/init/ready/Dockerfile
+++ b/containers/init/ready/Dockerfile
@@ -17,6 +17,11 @@ FROM golang:1.14
 RUN mkdir -p /src/ready
 WORKDIR /src/ready
 
+# This is to set up READY_TIMEOUT for ready.go to use. Default value is set
+# to avoid error.
+ARG READY_TIMEOUT_ARG=15m
+ENV READY_TIMEOUT=$READY_TIMEOUT_ARG
+
 COPY . .
 RUN go install ./containers/init/ready
 


### PR DESCRIPTION
This commits add READY_TIMEOUT as ARG in ready container's
Dockerfile. This is to ensure we can alter this environment
variable upon building the image.