### PR TITLE
Update Makefile for ready container timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ push-clone-image:
 # Build the ready init container image
 ready-image:
 	docker build -t ${INIT_IMAGE_PREFIX}ready:${TEST_INFRA_VERSION} \
-		-f containers/init/ready/Dockerfile .
+		-f containers/init/ready/Dockerfile --build-arg READY_TIMEOUT_ARG=20m .
 
 # Push the ready init container image to a docker registry
 push-ready-image:


### PR DESCRIPTION
This commit updates the Makefile target for building the ready
container image.