### PR TITLE
Update DefaultTimeout to 25m for ready container

### DIFF
--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -40,7 +40,7 @@ const TimeoutEnv = "READY_TIMEOUT"
 
 // DefaultTimeout specifies the amount of time to wait for ready pods if the
 // environment variable specified by the TimeoutEnv constant is not set.
-const DefaultTimeout = 15 * time.Minute
+const DefaultTimeout = 25 * time.Minute
 
 // OutputFileEnv is the optional name of the file where the executable should
 // write a comma-separated list of IP addresses. If this environment variable is


### PR DESCRIPTION
This commit update the DefaultTimeout to 25mins for ready
container. DefaultTimeout is used to exit driver when workers
take too long to be brought up and running. PHP load test
takes longer for workers to set up, this change helps driver to
stay long enough for that.