### PR TITLE
Add prebuilt image for Java

### DIFF
--- a/config/samples/java_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/java_example_loadtest_with_pre_built_workers.yaml
@@ -1,0 +1,124 @@
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  # Every load test instance must be assigned a unique name on the
+  # cluster. There are ways we can circumvent naming clashes, such
+  # as using namespaces or dynamically assigning names.
+  name: prebuilt-java-example
+
+  # As a custom resource, it behaves like a native kubernetes object.
+  # This means that users can perform CRUD operations through the
+  # Kubernetes API or kubectl. In addition, it means that the user
+  # can set any metadata on it.
+  labels:
+    language: java
+spec:
+  # The user can specify servers to use when running tests. The
+  # initial version only supports 1 server to limit scope. Servers
+  # is an array for future expansion.
+  #
+  # There are many designs and systems to pursue load balancing,
+  # organizing and monitoring a mesh of servers. Therefore, this
+  # will likely be expanded in the future.
+  servers:
+    - language: java
+      run:
+        image: gcr.io/grpc-testing/donghao/prebuilt/java
+        command:
+          ["/execute/bin/benchmark_worker"]
+
+  # Users can specify multiple clients. They are bound by the
+  # number of nodes.
+  clients:
+    - language: java
+      run:
+        image: gcr.io/grpc-testing/donghao/prebuilt/java
+        command:
+          ["/execute/bin/benchmark_worker"]
+
+  # We can optionally specify where to place the results. The
+  # controller will attempt to mount a service account in the driver.
+  # This can be used for uploading results to GCS or BigQuery.
+  # results:
+  #   bigQueryTable: "example-project.foo.demo_dataset"
+
+  # timeoutSeconds is an integer field that indicates the longest time a test
+  # is allowed to run, in seconds. Tests that run longer than the given value
+  # will be marked as Errored and will no longer be allocated resources to run.
+  # For example: timeoutSeconds: 900 indicates the timeout of this test
+  # is 15min. The minimum valid value for this field is 1.
+  timeoutSeconds: 900
+
+  # ttlSeconds is an integer field that indicates how long a test is allowed to
+  # live on the cluster, in seconds. Tests that live longer than the given value
+  # will be deleted. For example: ttlSeconds: 86400 indicates the time-to-live
+  # of this test is 24h. The minimum valid value for this field is 1.
+  ttlSeconds: 86400
+
+  # ScenariosJSON is string with the contents of a Scenarios message, formatted
+  # as JSON. See the Scenarios protobuf definition for details:
+  # https://github.com/grpc/grpc-proto/blob/master/grpc/testing/control.proto.
+  scenariosJSON: |
+    {
+      "scenarios": [
+        {
+          "name": "java_generic_async_streaming_ping_pong_secure",
+          "warmup_seconds": 15,
+          "benchmark_seconds": 30,
+          "num_servers": 1,
+          "server_config": {
+            "async_server_threads": 1,
+            "channel_args": [
+              {
+                "str_value": "latency",
+                "name": "grpc.optimization_target"
+              }
+            ],
+            "server_type": "ASYNC_GENERIC_SERVER",
+            "payload_config": {
+              "bytebuf_params": {
+                "resp_size": 0,
+                "req_size": 0
+              }
+            },
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "threads_per_cq": 0
+          },
+          "client_config": {
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "channel_args": [
+              {
+                "str_value": "latency",
+                "name": "grpc.optimization_target"
+              }
+            ],
+            "async_client_threads": 1,
+            "outstanding_rpcs_per_channel": 1,
+            "rpc_type": "STREAMING",
+            "payload_config": {
+              "bytebuf_params": {
+                "resp_size": 0,
+                "req_size": 0
+              }
+            },
+            "client_channels": 1,
+            "threads_per_cq": 0,
+            "load_params": {
+              "closed_loop": {}
+            },
+            "client_type": "ASYNC_CLIENT",
+            "histogram_params": {
+              "max_possible": 60000000000,
+              "resolution": 0.01
+            }
+          },
+          "num_clients": 1
+        }
+      ]
+    }

--- a/config/samples/java_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/java_example_loadtest_with_pre_built_workers.yaml
@@ -23,7 +23,7 @@ spec:
   servers:
     - language: java
       run:
-        image: ${prebuilt_image_prefix}/java
+        image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
         command:
           ["/execute/bin/benchmark_worker"]
 
@@ -32,7 +32,7 @@ spec:
   clients:
     - language: java
       run:
-        image: ${prebuilt_image_prefix}/java
+        image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
         command:
           ["/execute/bin/benchmark_worker"]
 

--- a/config/samples/java_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/java_example_loadtest_with_pre_built_workers.yaml
@@ -23,7 +23,7 @@ spec:
   servers:
     - language: java
       run:
-        image: gcr.io/grpc-testing/donghao/prebuilt/java
+        image: ${prebuilt_image_prefix}/java
         command:
           ["/execute/bin/benchmark_worker"]
 
@@ -32,7 +32,7 @@ spec:
   clients:
     - language: java
       run:
-        image: gcr.io/grpc-testing/donghao/prebuilt/java
+        image: ${prebuilt_image_prefix}/java
         command:
           ["/execute/bin/benchmark_worker"]
 

--- a/containers/pre_built_workers/java/Dockerfile
+++ b/containers/pre_built_workers/java/Dockerfile
@@ -23,6 +23,11 @@ ARG GITREF=master
 RUN git clone https://github.com/$REPOSITORY.git .
 RUN git submodule update --init
 RUN git checkout $GITREF
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
 RUN gradle -PskipAndroid=true -PskipCodegen=true :grpc-benchmarks:installDist
 
 FROM openjdk:8
@@ -30,11 +35,6 @@ FROM openjdk:8
 RUN mkdir -p /execute
 WORKDIR /execute
 COPY --from=0 /pre/benchmarks/build/install/grpc-benchmarks /execute
-RUN apt-get update && apt-get install -y \
-  bash \
-  curl \
-  git \
-  time && \
-  apt-get clean
+COPY --from=0 /pre/GRPC_GIT_COMMIT.txt /execute/GRPC_GIT_COMMIT.txt
 
 CMD ["bash"]

--- a/containers/pre_built_workers/java/Dockerfile
+++ b/containers/pre_built_workers/java/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gradle:jdk8
+
+RUN mkdir -p /pre
+WORKDIR /pre
+
+ARG REPOSITORY=grpc/grpc-java
+ARG GITREF=master
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+RUN git checkout $GITREF
+RUN gradle -PskipAndroid=true -PskipCodegen=true :grpc-benchmarks:installDist
+
+FROM openjdk:8
+
+RUN mkdir -p /execute
+WORKDIR /execute
+COPY --from=0 /pre/benchmarks/build/install/grpc-benchmarks /execute
+RUN apt-get update && apt-get install -y \
+  bash \
+  curl \
+  git \
+  time && \
+  apt-get clean
+
+CMD ["bash"]


### PR DESCRIPTION
Java image is built by gradle from grpc/grpc-java.
After built, bone structure/binary is extracted to a new image to shrink the final image's size.
The build procedure mimic the init-containers' clone, build and run steps.
I have verified the prebuilt image on benchmark-prod reaching the same stage as regular multi-stage images.
The image size:
```
02572dcb28fb   7 days ago    /bin/sh -c #(nop) COPY file:6322b0b59c64195b…   52B       
dfcb4586e6c0   7 days ago    /bin/sh -c #(nop) COPY dir:8f5e0673142d3e992…   19.6MB 
```
So approximately 19.6MB would be pushed to gcr.io.
Using prebuilt image, we can complete the performance test within 56s while we need 3m28s to finish using multi-stage images. Thus, we can save approximately 2m30s. 