### PR TITLE
Add prebuilt image for ruby

### DIFF
--- a/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
@@ -23,7 +23,7 @@ spec:
   servers:
   - language: ruby
     run:
-      image: gcr.io/grpc-testing/donghao/prebuilt/ruby
+      image: ${prebuilt_image_prefix}/ruby
       command: [ "ruby" ]
       args: [ "/execute/src/ruby/qps/worker.rb" ]
 
@@ -32,7 +32,7 @@ spec:
   clients:
   - language: ruby
     run:
-      image: gcr.io/grpc-testing/donghao/prebuilt/ruby
+      image: ${prebuilt_image_prefix}/ruby
       command: [ "ruby" ]
       args: [ "/execute/src/ruby/qps/worker.rb" ]
 

--- a/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
@@ -1,0 +1,121 @@
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  # Every load test instance must be assigned a unique name on the
+  # cluster. There are ways we can circumvent naming clashes, such
+  # as using namespaces or dynamically assigning names.
+  name: prebuilt-ruby-example
+
+  # As a custom resource, it behaves like a native kubernetes object.
+  # This means that users can perform CRUD operations through the
+  # Kubernetes API or kubectl. In addition, it means that the user
+  # can set any metadata on it.
+  labels:
+    language: ruby
+spec:
+  # The user can specify servers to use when running tests. The
+  # initial version only supports 1 server to limit scope. Servers
+  # is an array for future expansion.
+  #
+  # There are many designs and systems to pursue load balancing,
+  # organizing and monitoring a mesh of servers. Therefore, this
+  # will likely be expanded in the future.
+  servers:
+  - language: ruby
+    run:
+      image: gcr.io/grpc-testing/donghao/prebuilt/ruby
+      command: [ "ruby" ]
+      args: [ "/execute/src/ruby/qps/worker.rb" ]
+
+  # Users can specify multiple clients. They are bound by the
+  # number of nodes.
+  clients:
+  - language: ruby
+    run:
+      image: gcr.io/grpc-testing/donghao/prebuilt/ruby
+      command: [ "ruby" ]
+      args: [ "/execute/src/ruby/qps/worker.rb" ]
+
+  # We can optionally specify where to place the results. The
+  # controller will attempt to mount a service account in the driver.
+  # This can be used for uploading results to GCS or BigQuery.
+  # results:
+  #   bigQueryTable: "example-project.foo.demo_dataset"
+
+  # timeoutSeconds is an integer field that indicates the longest time a test
+  # is allowed to run, in seconds. Tests that run longer than the given value
+  # will be marked as Errored and will no longer be allocated resources to run.
+  # For example: timeoutSeconds: 900 indicates the timeout of this test
+  # is 15min. The minimum valid value for this field is 1.
+  timeoutSeconds: 900
+
+  # ttlSeconds is an integer field that indicates how long a test is allowed to
+  # live on the cluster, in seconds. Tests that live longer than the given value
+  # will be deleted. For example: ttlSeconds: 86400 indicates the time-to-live
+  # of this test is 24h. The minimum valid value for this field is 1.
+  ttlSeconds: 86400
+
+  # ScenariosJSON is string with the contents of a Scenarios message, formatted
+  # as JSON. See the Scenarios protobuf definition for details:
+  # https://github.com/grpc/grpc-proto/blob/master/grpc/testing/control.proto.
+  scenariosJSON: |
+    {
+      "scenarios": [
+        {
+          "name": "ruby_protobuf_sync_streaming_ping_pong",
+          "num_servers": 1,
+          "num_clients": 1,
+          "client_config": {
+            "client_type": "SYNC_CLIENT",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "outstanding_rpcs_per_channel": 1,
+            "client_channels": 1,
+            "async_client_threads": 1,
+            "client_processes": 0,
+            "threads_per_cq": 0,
+            "rpc_type": "STREAMING",
+            "histogram_params": {
+              "resolution": 0.01,
+              "max_possible": 60000000000.0
+            },
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ],
+            "payload_config": {
+              "simple_params": {
+                "req_size": 0,
+                "resp_size": 0
+              }
+            },
+            "load_params": {
+              "closed_loop": {}
+            }
+          },
+          "server_config": {
+            "server_type": "SYNC_SERVER",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "async_server_threads": 0,
+            "server_processes": 0,
+            "threads_per_cq": 0,
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ]
+          },
+          "warmup_seconds": 5,
+          "benchmark_seconds": 30
+        }
+      ]
+    }
+

--- a/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/ruby_example_loadtest_with_pre_built_workers.yaml
@@ -23,7 +23,7 @@ spec:
   servers:
   - language: ruby
     run:
-      image: ${prebuilt_image_prefix}/ruby
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       command: [ "ruby" ]
       args: [ "/execute/src/ruby/qps/worker.rb" ]
 
@@ -32,7 +32,7 @@ spec:
   clients:
   - language: ruby
     run:
-      image: ${prebuilt_image_prefix}/ruby
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       command: [ "ruby" ]
       args: [ "/execute/src/ruby/qps/worker.rb" ]
 

--- a/containers/pre_built_workers/ruby/Dockerfile
+++ b/containers/pre_built_workers/ruby/Dockerfile
@@ -24,6 +24,9 @@ RUN git clone https://github.com/$REPOSITORY.git .
 RUN git submodule update --init
 RUN git checkout $GITREF
 
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 
 ENV GEM_HOME=/pre/vendor/bundle/
 RUN apt-get update && apt-get install -y cmake && apt-get clean
@@ -40,11 +43,8 @@ WORKDIR /execute
 COPY --from=0 /pre/src /execute/src
 COPY --from=0 /pre/vendor/bundle /execute/vendor/bundle
 COPY --from=0 /pre/etc /execute/etc
-ENV GEM_HOME=/execute/vendor/bundle/
+COPY --from=0 /pre/GRPC_GIT_COMMIT.txt /execute/GRPC_GIT_COMMIT.txt
 
-RUN apt-get update && apt-get install -y \
-  git \
-  time && \
-  apt-get clean
+ENV GEM_HOME=/execute/vendor/bundle/
 
 CMD ["bash"]

--- a/containers/pre_built_workers/ruby/Dockerfile
+++ b/containers/pre_built_workers/ruby/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ruby:2.5
+
+RUN mkdir -p /pre
+WORKDIR /pre
+
+ARG REPOSITORY=grpc/grpc
+ARG GITREF=master
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+RUN git checkout $GITREF
+
+
+ENV GEM_HOME=/pre/vendor/bundle/
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+RUN mkdir /build_scripts
+ADD build_qps_worker.sh /build_scripts
+RUN bash /build_scripts/build_qps_worker.sh
+
+# Copy node modules to a new image
+FROM ruby:2.5
+
+RUN mkdir -p /execute
+WORKDIR /execute
+COPY --from=0 /pre/src /execute/src
+COPY --from=0 /pre/vendor/bundle /execute/vendor/bundle
+COPY --from=0 /pre/etc /execute/etc
+ENV GEM_HOME=/execute/vendor/bundle/
+
+RUN apt-get update && apt-get install -y \
+  git \
+  time && \
+  apt-get clean
+
+CMD ["bash"]

--- a/containers/pre_built_workers/ruby/build_qps_worker.sh
+++ b/containers/pre_built_workers/ruby/build_qps_worker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# change to grpc's ruby directory
+set -ex
+
+bundle install
+
+rake compile
+
+# build grpc_ruby_plugin
+mkdir -p cmake/build
+pushd cmake/build
+cmake -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=$Release ../..
+make protoc grpc_ruby_plugin -j2
+popd
+
+# unbreak subsequent make builds by restoring zconf.h (previously renamed by cmake build)
+# see https://github.com/madler/zlib/issues/133
+(cd third_party/zlib; git checkout zconf.h)


### PR DESCRIPTION
Ruby image is built by bundle, rake, cmake from grpc/grpc.
After built, bone structure/binary is extracted to a new image to shrink the final image's size.
The build procedure mimic the init-containers' clone, build and run steps.
I have verified the prebuilt image on benchmark-prod reaching the same stage as regular multi-stage images.
The image size:
```
55dde96d8841   7 days ago    /bin/sh -c #(nop) COPY file:91288581a205eb37…   52B       
03cc5e005684   7 days ago    /bin/sh -c #(nop) COPY dir:17f0ec771f5339353…   264kB     
7bfaeed7ea16   7 days ago    /bin/sh -c #(nop) COPY dir:7faa2ab1498217156…   20.8MB    
6d6fc038cb97   10 days ago   /bin/sh -c #(nop) COPY dir:9afd81795b8e120b8…   26.7MB  
```
So approximately 47.5MB would be pushed to gcr.io.
Using prebuilt image, we can complete the performance test within 45s while we need 7m to finish using multi-stage images. Thus, we can save approximately 6m15s. 
