### PR TITLE
Feature/Add pre-built go example and Dockerfile

### DIFF
--- a/config/samples/go_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/go_example_loadtest_with_pre_built_workers.yaml
@@ -1,0 +1,128 @@
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  # Every load test instance must be assigned a unique name on the
+  # cluster. There are ways we can circumvent naming clashes, such
+  # as using namespaces or dynamically assigning names.
+  name: prebuilt-go-example
+
+  # As a custom resource, it behaves like a native kubernetes object.
+  # This means that users can perform CRUD operations through the
+  # Kubernetes API or kubectl. In addition, it means that the user
+  # can set any metadata on it.
+  labels:
+    language: go
+spec:
+  # The user can specify servers to use when running tests. The
+  # initial version only supports 1 server to limit scope. Servers
+  # is an array for future expansion.
+  #
+  # There are many designs and systems to pursue load balancing,
+  # organizing and monitoring a mesh of servers. Therefore, this
+  # will likely be expanded in the future.
+  servers:
+    - language: go
+      run:
+        image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+        command: ["/executable/worker"]
+
+
+  # Users can specify multiple clients. They are bound by the
+  # number of nodes.
+  clients:
+    - language: go
+      run:
+        image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}gcloud container clusters get-credentials benchmarks-dev1 \
+          --zone us-central1-b \
+          --project grpc-testing
+        command: ["/executable/worker"]
+
+  # We can optionally specify where to place the results. The
+  # controller will attempt to mount a service account in the driver.
+  # This can be used for uploading results to GCS or BigQuery.
+  # results:
+  #   bigQueryTable: "example-project.foo.demo_dataset"
+
+  # timeoutSeconds is an integer field that indicates the longest time a test
+  # is allowed to run, in seconds. Tests that run longer than the given value
+  # will be marked as Errored and will no longer be allocated resources to run.
+  # For example: timeoutSeconds: 900 indicates the timeout of this test
+  # is 15min. The minimum valid value for this field is 1.
+  timeoutSeconds: 900
+
+  # ttlSeconds is an integer field that indicates how long a test is allowed to
+  # live on the cluster, in seconds. Tests that live longer than the given value
+  # will be deleted. For example: ttlSeconds: 86400 indicates the time-to-live
+  # of this test is 24h. The minimum valid value for this field is 1.
+  ttlSeconds: 86400
+
+  # ScenariosJSON is string with the contents of a Scenarios message, formatted
+  # as JSON. See the Scenarios protobuf definition for details:
+  # https://github.com/grpc/grpc-proto/blob/master/grpc/testing/control.proto.
+  scenariosJSON: |
+    {
+      "scenarios": [
+        {
+          "name": "go_generic_sync_streaming_ping_pong_secure",
+          "warmup_seconds": 5,
+          "benchmark_seconds": 30,
+          "num_servers": 1,
+          "server_config": {
+            "async_server_threads": 1,
+            "channel_args": [
+              {
+                "str_value": "latency",
+                "name": "grpc.optimization_target"
+              }
+            ],
+            "payload_config": {
+              "bytebuf_params": {
+                "resp_size": 0,
+                "req_size": 0
+              }
+            },
+            "security_params": {
+              "server_host_override": "foo.test.google.fr",
+              "use_test_ca": true
+            },
+            "server_processes": 0,
+            "server_type": "ASYNC_GENERIC_SERVER",
+            "threads_per_cq": 0
+          },
+          "num_clients": 1,
+          "client_config": {
+            "async_client_threads": 1,
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ],
+            "client_channels": 1,
+            "client_processes": 0,
+            "client_type": "SYNC_CLIENT",
+            "histogram_params": {
+              "max_possible": 60000000000,
+              "resolution": 0.01
+            },
+            "load_params": {
+              "closed_loop": {}
+            },
+            "outstanding_rpcs_per_channel": 1,
+            "payload_config": {
+              "bytebuf_params": {
+                "req_size": 0,
+                "resp_size": 0
+              }
+            },
+            "rpc_type": "STREAMING",
+            "security_params": {
+              "server_host_override": "foo.test.google.fr",
+              "use_test_ca": true
+            },
+            "threads_per_cq": 0
+          },
+        }
+      ]
+    }
+

--- a/config/samples/go_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/go_example_loadtest_with_pre_built_workers.yaml
@@ -24,7 +24,7 @@ spec:
     - language: go
       run:
         image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
-        command: ["/executable/worker"]
+        command: ["/executable/bin/worker"]
 
 
   # Users can specify multiple clients. They are bound by the
@@ -32,10 +32,8 @@ spec:
   clients:
     - language: go
       run:
-        image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}gcloud container clusters get-credentials benchmarks-dev1 \
-          --zone us-central1-b \
-          --project grpc-testing
-        command: ["/executable/worker"]
+        image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+        command: ["/executable/bin/worker"]
 
   # We can optionally specify where to place the results. The
   # controller will attempt to mount a service account in the driver.

--- a/containers/pre_built_workers/go/Dockerfile
+++ b/containers/pre_built_workers/go/Dockerfile
@@ -36,7 +36,8 @@ FROM debian:buster
 
 RUN mkdir -p /executable
 WORKDIR /executable
-COPY --from=0 /executable/bin/worker /executable
+COPY --from=0 /executable/GRPC_GIT_COMMIT.txt /executable/GRPC_GIT_COMMIT.txt
+COPY --from=0 /executable/bin/worker /executable/bin/worker
 COPY --from=0 /executable/testdata /executable/testdata
 
 CMD ["bash"]

--- a/containers/pre_built_workers/go/Dockerfile
+++ b/containers/pre_built_workers/go/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14
+
+RUN mkdir -p /executable
+WORKDIR /executable
+
+ARG REPOSITORY=grpc/grpc-go
+ARG GITREF=master
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+RUN git checkout $GITREF
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
+# Build go excutables
+RUN go build -o /executable/bin/worker ./benchmark/worker
+
+# Copy go excuatable to a new image
+FROM debian:buster
+
+RUN mkdir -p /executable
+WORKDIR /executable
+COPY --from=0 /executable/bin/worker /executable
+COPY --from=0 /executable/testdata /executable/testdata
+
+CMD ["bash"]


### PR DESCRIPTION
This commits add the Dockerfile that contains a pre-built
go-worker and a example load test configuration file example to
use such pre-built workers.