### PR TITLE
Set ready container's timeout equal to loadtest's timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ push-clone-image:
 # Build the ready init container image
 ready-image:
 	docker build -t ${INIT_IMAGE_PREFIX}ready:${TEST_INFRA_VERSION} \
-		-f containers/init/ready/Dockerfile --build-arg READY_TIMEOUT_ARG=20m .
+		-f containers/init/ready/Dockerfile .
 
 # Push the ready init container image to a docker registry
 push-ready-image:

--- a/config/samples/php_example_loadtest.yaml
+++ b/config/samples/php_example_loadtest.yaml
@@ -51,9 +51,9 @@ spec:
   # timeoutSeconds is an integer field that indicates the longest time a test
   # is allowed to run, in seconds. Tests that run longer than the given value
   # will be marked as Errored and will no longer be allocated resources to run.
-  # For example: timeoutSeconds: 900 indicates the timeout of this test
-  # is 15min. The minimum valid value for this field is 1.
-  timeoutSeconds: 900
+  # For example: timeoutSeconds: 1200 indicates the timeout of this test
+  # is 20min. The minimum valid value for this field is 1.
+  timeoutSeconds: 1200
 
   # ttlSeconds is an integer field that indicates how long a test is allowed to
   # live on the cluster, in seconds. Tests that live longer than the given value

--- a/containers/init/ready/Dockerfile
+++ b/containers/init/ready/Dockerfile
@@ -17,11 +17,6 @@ FROM golang:1.14
 RUN mkdir -p /src/ready
 WORKDIR /src/ready
 
-# This is to set up READY_TIMEOUT for ready.go to use. Default value is set
-# to avoid error.
-ARG READY_TIMEOUT_ARG=15m
-ENV READY_TIMEOUT=$READY_TIMEOUT_ARG
-
 COPY . .
 RUN go install ./containers/init/ready
 

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -52,7 +52,6 @@ func addReadyInitContainer(defs *config.Defaults, test *grpcv1.LoadTest, podspec
 		Name:  "QPS_WORKERS_FILE",
 		Value: config.ReadyOutputFile,
 	})
-
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      config.ReadyVolumeName,
 		MountPath: config.ReadyMountPath,
@@ -95,6 +94,10 @@ func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Cont
 			{
 				Name:  "READY_OUTPUT_FILE",
 				Value: config.ReadyOutputFile,
+			},
+			{
+				Name:  "READY_TIMEOUT",
+				Value: fmt.Sprintf("%d%s", test.Spec.TimeoutSeconds, "s"),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -52,6 +52,7 @@ func addReadyInitContainer(defs *config.Defaults, test *grpcv1.LoadTest, podspec
 		Name:  "QPS_WORKERS_FILE",
 		Value: config.ReadyOutputFile,
 	})
+
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      config.ReadyVolumeName,
 		MountPath: config.ReadyMountPath,


### PR DESCRIPTION
Set the ready container's timeout equal to the loadtest's timeoutSeconds; Remove the build TIMEOUT argument for ready container. The timeout environment variable would be set in runtime.