### PR TITLE
Add prebuilt image for PHP

### DIFF
--- a/config/samples/php_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/php_example_loadtest_with_pre_built_workers.yaml
@@ -1,0 +1,119 @@
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  # Every load test instance must be assigned a unique name on the
+  # cluster. There are ways we can circumvent naming clashes, such
+  # as using namespaces or dynamically assigning names.
+  name: prebuilt-php-example
+
+  # As a custom resource, it behaves like a native kubernetes object.
+  # This means that users can perform CRUD operations through the
+  # Kubernetes API or kubectl. In addition, it means that the user
+  # can set any metadata on it.
+  labels:
+    language: php
+spec:
+  # The user can specify servers to use when running tests. The
+  # initial version only supports 1 server to limit scope. Servers
+  # is an array for future expansion.
+  #
+  # There are many designs and systems to pursue load balancing,
+  # organizing and monitoring a mesh of servers. Therefore, this
+  # will likely be expanded in the future.
+  servers:
+  - language: php
+    run:
+      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
+      command: [ "bash", "/run_scripts/run_worker.sh" ]
+
+  # Users can specify multiple clients. They are bound by the
+  # number of nodes.
+  clients:
+  - language: php
+    run:
+      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
+      command: [ "bash", "/run_scripts/run_worker.sh" ]
+
+  # We can optionally specify where to place the results. The
+  # controller will attempt to mount a service account in the driver.
+  # This can be used for uploading results to GCS or BigQuery.
+  # results:
+  #   bigQueryTable: "example-project.foo.demo_dataset"
+
+  # timeoutSeconds is an integer field that indicates the longest time a test
+  # is allowed to run, in seconds. Tests that run longer than the given value
+  # will be marked as Errored and will no longer be allocated resources to run.
+  # For example: timeoutSeconds: 1200 indicates the timeout of this test
+  # is 20min. The minimum valid value for this field is 1.
+  timeoutSeconds: 1200
+
+  # ttlSeconds is an integer field that indicates how long a test is allowed to
+  # live on the cluster, in seconds. Tests that live longer than the given value
+  # will be deleted. For example: ttlSeconds: 86400 indicates the time-to-live
+  # of this test is 24h. The minimum valid value for this field is 1.
+  ttlSeconds: 86400
+
+  # ScenariosJSON is string with the contents of a Scenarios message, formatted
+  # as JSON. See the Scenarios protobuf definition for details:
+  # https://github.com/grpc/grpc-proto/blob/master/grpc/testing/control.proto.
+  scenariosJSON: |
+    {
+      "scenarios": [
+        {
+          "name": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong",
+          "num_servers": 1,
+          "num_clients": 1,
+          "client_config": {
+            "client_type": "SYNC_CLIENT",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "outstanding_rpcs_per_channel": 1,
+            "client_channels": 1,
+            "async_client_threads": 1,
+            "client_processes": 0,
+            "threads_per_cq": 0,
+            "rpc_type": "UNARY",
+            "histogram_params": {
+              "resolution": 0.01,
+              "max_possible": 60000000000.0
+            },
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ],
+            "payload_config": {
+              "simple_params": {
+                "req_size": 0,
+                "resp_size": 0
+              }
+            },
+            "load_params": {
+              "closed_loop": {}
+            }
+          },
+          "server_config": {
+            "server_type": "SYNC_SERVER",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "async_server_threads": 1,
+            "server_processes": 0,
+            "threads_per_cq": 0,
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ]
+          },
+          "warmup_seconds": 5,
+          "benchmark_seconds": 30
+        }
+      ]
+    }
+

--- a/containers/pre_built_workers/php/Dockerfile
+++ b/containers/pre_built_workers/php/Dockerfile
@@ -1,0 +1,93 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2.22-buster
+
+RUN mkdir -p /pre
+WORKDIR /pre
+
+RUN apt-get update && apt-get install -y \
+  git \
+  zlib1g-dev \
+  build-essential \
+  lcov \
+  make \
+  gnupg2 && \
+  apt-get clean
+
+ARG REPOSITORY=grpc/grpc
+ARG GITREF=master
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+RUN git checkout $GITREF
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
+# Install rvm
+RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN \curl -sSL https://get.rvm.io | bash -s stable
+
+# Install Ruby 2.5
+RUN apt-get update && apt-get install -y procps && apt-get clean
+RUN /bin/bash -l -c "rvm install ruby-2.5"
+RUN /bin/bash -l -c "rvm use --default ruby-2.5"
+RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+
+RUN mkdir /build_scripts
+ADD build_qps_worker.sh /build_scripts
+RUN /build_scripts/build_qps_worker.sh
+
+FROM php:7.2.22-buster
+
+RUN mkdir -p /execute
+WORKDIR /execute
+COPY --from=0 /pre/src /execute/src
+COPY --from=0 /pre/etc /execute/etc
+COPY --from=0 /pre/saved/bundle/ /execute/saved/bundle/
+COPY --from=0 /pre/GRPC_GIT_COMMIT.txt /execute/GRPC_GIT_COMMIT.txt
+
+RUN apt-get update && apt-get install -y \
+  zlib1g-dev \
+  build-essential \
+  lcov \
+  make \
+  gnupg2 \
+  procps && \
+  apt-get clean
+
+# Install rvm
+RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN \curl -sSL https://get.rvm.io | bash -s stable
+
+# Install Ruby 2.5
+RUN /bin/bash -l -c "rvm install ruby-2.5"
+RUN /bin/bash -l -c "rvm use --default ruby-2.5"
+RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
+
+RUN mkdir /run_scripts
+ADD run_worker.sh /run_scripts
+CMD ["bash"]

--- a/containers/pre_built_workers/php/build_qps_worker.sh
+++ b/containers/pre_built_workers/php/build_qps_worker.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+export GRPC_LIB_SUBDIR="libs/opt"
+export CFLAGS="-Wno-parentheses-equality"
+export root="/pre"
+
+make static_c shared_c EMBED_OPENSSL=true EMBED_ZLIB=true
+
+cd src/php/ext/grpc
+
+phpize
+./configure --enable-grpc="/pre" --enable-coverage --enable-tests
+
+cd /pre/src/php/tests/qps
+
+composer install
+
+cd ../../../../third_party/protobuf/php/ext/google/protobuf
+
+phpize
+./configure
+
+# Prepare for ruby proxy workers
+source /usr/local/rvm/scripts/rvm
+mkdir -p /pre/saved/bundle/
+export GEM_HOME=/pre/saved/bundle/
+bundle install
+rake compile

--- a/containers/pre_built_workers/php/run_worker.sh
+++ b/containers/pre_built_workers/php/run_worker.sh
@@ -1,0 +1,18 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+source /usr/local/rvm/scripts/rvm
+export GEM_HOME=/execute/saved/bundle/
+ruby /execute/src/ruby/qps/proxy-worker.rb


### PR DESCRIPTION
The build procedure mimic the init-containers' clone, build and run steps.
I have verified the prebuilt image on benchmark-prod reaching the same stage as regular multi-stage images.
The image size:
```
fbdcef8193ed   25 minutes ago   /bin/sh -c #(nop) ADD file:d8bd2cc93683d8fc7…   702B      
af5fb8bf4b67   29 minutes ago   /bin/sh -c mkdir /run_scripts                   0B        
48c640292a90   41 minutes ago   /bin/sh -c /bin/bash -l -c "gem install bund…   1.09MB    
fdac70a1de65   41 minutes ago   /bin/sh -c /bin/bash -l -c "echo 'rvm --defa…   689B      
4e7a357ef99f   42 minutes ago   /bin/sh -c /bin/bash -l -c "echo 'export PAT…   662B      
33fb66a6465f   42 minutes ago   /bin/sh -c /bin/bash -l -c "echo 'gem: --no-…   19B       
d921cd1dc047   42 minutes ago   /bin/sh -c /bin/bash -l -c "rvm use --defaul…   7.34kB    
d6bfb3e724da   42 minutes ago   /bin/sh -c /bin/bash -l -c "rvm install ruby…   82.6MB    
6015ec853594   43 minutes ago   /bin/sh -c \curl -sSL https://get.rvm.io | b…   9.21MB    
ca9e8bf1ccf1   43 minutes ago   /bin/sh -c gpg2 --keyserver hkp://pool.sks-k…   17.5kB    
13d7b2f011fd   43 minutes ago   /bin/sh -c apt-get update && apt-get install…   39.4MB    
525271ed97ba   2 hours ago      /bin/sh -c #(nop) COPY file:e2939d90e24e4cb6…   52B       
193425a62bc9   2 hours ago      /bin/sh -c #(nop) COPY dir:b2b754409c25035a3…   20.8MB    
81354ff3c56b   2 hours ago      /bin/sh -c #(nop) COPY dir:17f0ec771f5339353…   264kB     
64534c1dbcd4   2 hours ago      /bin/sh -c #(nop) COPY dir:10ca3ff7e021e281f…   31.1MB
```
So approximately 183MB would be pushed to gcr.io.
Using prebuilt image, we can save around 16m for performance test(skipping clone and build stage).