### PR TITLE
Add prebuilt image for CSharp

### DIFF
--- a/config/samples/csharp_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/csharp_example_loadtest_with_pre_built_workers.yaml
@@ -1,0 +1,120 @@
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  # Every load test instance must be assigned a unique name on the
+  # cluster. There are ways we can circumvent naming clashes, such
+  # as using namespaces or dynamically assigning names.
+  name: prebuilt-csharp-example
+
+  # As a custom resource, it behaves like a native kubernetes object.
+  # This means that users can perform CRUD operations through the
+  # Kubernetes API or kubectl. In addition, it means that the user
+  # can set any metadata on it.
+  labels:
+    language: csharp
+spec:
+  # The user can specify servers to use when running tests. The
+  # initial version only supports 1 server to limit scope. Servers
+  # is an array for future expansion.
+  #
+  # There are many designs and systems to pursue load balancing,
+  # organizing and monitoring a mesh of servers. Therefore, this
+  # will likely be expanded in the future.
+  servers:
+  - language: csharp
+    run:
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      command: ["dotnet"]
+      args: ["exec", "/execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll"]
+
+  # Users can specify multiple clients. They are bound by the
+  # number of nodes.
+  clients:
+  - language: csharp
+    run:
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      command: ["dotnet"]
+      args: ["exec", "/execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll"]
+
+  # We can optionally specify where to place the results. The
+  # controller will attempt to mount a service account in the driver.
+  # This can be used for uploading results to GCS or BigQuery.
+  # results:
+  #   bigQueryTable: "example-project.foo.demo_dataset"
+
+  # timeoutSeconds is an integer field that indicates the longest time a test
+  # is allowed to run, in seconds. Tests that run longer than the given value
+  # will be marked as Errored and will no longer be allocated resources to run.
+  # For example: timeoutSeconds: 900 indicates the timeout of this test
+  # is 15min. The minimum valid value for this field is 1.
+  timeoutSeconds: 900
+
+  # ttlSeconds is an integer field that indicates how long a test is allowed to
+  # live on the cluster, in seconds. Tests that live longer than the given value
+  # will be deleted. For example: ttlSeconds: 86400 indicates the time-to-live
+  # of this test is 24h. The minimum valid value for this field is 1.
+  ttlSeconds: 86400
+
+  # ScenariosJSON is string with the contents of a Scenarios message, formatted
+  # as JSON. See the Scenarios protobuf definition for details:
+  # https://github.com/grpc/grpc-proto/blob/master/grpc/testing/control.proto.
+  scenariosJSON: |
+    {
+      "scenarios": [
+        {
+          "name": "csharp_protobuf_async_unary_ping_pong",
+          "num_servers": 1,
+          "num_clients": 1,
+          "client_config": {
+            "client_type": "ASYNC_CLIENT",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "outstanding_rpcs_per_channel": 1,
+            "client_channels": 1,
+            "async_client_threads": 1,
+            "client_processes": 0,
+            "threads_per_cq": 0,
+            "rpc_type": "UNARY",
+            "histogram_params": {
+              "resolution": 0.01,
+              "max_possible": 60000000000.0
+            },
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ],
+            "payload_config": {
+              "simple_params": {
+                "req_size": 0,
+                "resp_size": 0
+              }
+            },
+            "load_params": {
+              "closed_loop": {}
+            }
+          },
+          "server_config": {
+            "server_type": "ASYNC_SERVER",
+            "security_params": {
+              "use_test_ca": true,
+              "server_host_override": "foo.test.google.fr"
+            },
+            "async_server_threads": 0,
+            "server_processes": 0,
+            "threads_per_cq": 0,
+            "channel_args": [
+              {
+                "name": "grpc.optimization_target",
+                "str_value": "latency"
+              }
+            ]
+          },
+          "warmup_seconds": 5,
+          "benchmark_seconds": 30
+        }
+      ]
+    }

--- a/containers/pre_built_workers/csharp/Dockerfile
+++ b/containers/pre_built_workers/csharp/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/dotnet/sdk:2.1
+
+RUN mkdir -p /pre
+WORKDIR /pre
+
+ARG REPOSITORY=grpc/grpc
+ARG GITREF=master
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git submodule update --init
+RUN git checkout $GITREF
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  git \
+  cmake && \
+  apt-get clean
+
+# Currently C# is little tricky to build with a single command, so we inject a script that can take care of the build.
+RUN mkdir /build_scripts
+ADD build_qps_worker.sh /build_scripts
+RUN /build_scripts/build_qps_worker.sh
+
+FROM mcr.microsoft.com/dotnet/runtime:2.1
+
+RUN mkdir -p /execute
+WORKDIR /execute
+COPY --from=0 /pre/etc /execute/etc
+COPY --from=0 /pre/qps_worker /execute/qps_worker
+COPY --from=0 /pre/GRPC_GIT_COMMIT.txt /execute/GRPC_GIT_COMMIT.txt
+
+CMD ["bash"]

--- a/containers/pre_built_workers/csharp/build_qps_worker.sh
+++ b/containers/pre_built_workers/csharp/build_qps_worker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Build C# native extension with cmake
+mkdir -p cmake/build
+pushd cmake/build
+cmake -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release ../..
+make grpc_csharp_ext
+popd
+
+cd src/csharp
+dotnet publish Grpc.IntegrationTesting.QpsWorker/ -c Release -f netcoreapp2.1 -o ../../../qps_worker


### PR DESCRIPTION
CSharp image is built by cmake from grpc/grpc.
After built, bone structure/binary is extracted to a new image to shrink the final image's size.
The build procedure mimic the init-containers' clone, build and run steps.
I have verified the prebuilt image on benchmark-prod reaching the same stage as regular multi-stage images.
The image size:
```
920fda23a4fd   16 hours ago   /bin/sh -c #(nop) COPY file:e2939d90e24e4cb6…   52B       
0b7ec482ac03   16 hours ago   /bin/sh -c #(nop) COPY dir:e42eec35571d2366b…   12MB      
c048571e38e7   16 hours ago   /bin/sh -c #(nop) COPY dir:17f0ec771f5339353…   264kB 
```
So approximately 12MB would be pushed to gcr.io.
Using prebuilt image, we can complete the performance test within 2m49s while we need 12m to finish using multi-stage images. Thus, we can save approximately 9m. 