### PR TITLE
Remove resource quotas for deployments

### DIFF
--- a/config/cleanup_agent/cleanup_agent.yaml
+++ b/config/cleanup_agent/cleanup_agent.yaml
@@ -26,11 +26,4 @@ spec:
       - command:
         image: cleanup_agent:latest
         name: manager
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,11 +30,4 @@ spec:
         - --reconciliation-timeout=2m
         image: controller:latest
         name: manager
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This commit removes the resource quotas for the load test controller and the cleanup agent. The resource quotas were leading to out of memory restarts when batch testing.