### PR TITLE
Fix system node selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,21 @@
 # Version tag for all images
 TEST_INFRA_VERSION ?= "latest"
-
 # Version of the gRPC driver
 DRIVER_VERSION ?= "master"
-
 # Prefix for all images used as clone and ready containers, enabling use with registries
 # other than DockerHub
 INIT_IMAGE_PREFIX ?= ""
-
 # Prefix for all images used as build containers, enabling use with registries
 # other than DockerHub
 BUILD_IMAGE_PREFIX ?= ""
-
 # Prefix for all images used as runtime containers, enabling use with registries
 # other than DockerHub
 IMAGE_PREFIX ?= ""
-
 # Image URL to use all building/pushing image targets
 CONTROLLER_IMG ?= ${IMAGE_PREFIX}controller:${TEST_INFRA_VERSION}
-
 # Image URL to use all building/pushing image targets
 CLEAN_IMG ?= ${IMAGE_PREFIX}cleanup:${TEST_INFRA_VERSION}
-
-# Node pool for system components (controller and cleanup agent)
-SYSTEM_POOL ?= "system"
-
+#${IMAGE_PREFIX}cleanup_agent:${TEST_INFRA_VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -62,16 +53,12 @@ deploy: deploy-controller deploy-cleanup-agent
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy-controller: manifests
-	cd config/manager && \
-		kustomize edit set image controller=${CONTROLLER_IMG} && \
-		kustomize edit set label pool:${SYSTEM_POOL}
+	cd config/manager && kustomize edit set image controller=${CONTROLLER_IMG}
 	kustomize build config/default | kubectl apply -f -
 
 # Deploy cleanup_agent in the configured Kubernetes cluster in ~/.kube/config
 deploy-cleanup-agent: manifests
-	cd config/cleanup_agent && \
-		kustomize edit set image cleanup_agent=${CLEAN_IMG} && \
-		kustomize edit set label pool:${SYSTEM_POOL}
+	cd config/cleanup_agent && kustomize edit set image cleanup_agent=${CLEAN_IMG}
 	kustomize build config/cleanup_agent | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ IMAGE_PREFIX ?= ""
 CONTROLLER_IMG ?= ${IMAGE_PREFIX}controller:${TEST_INFRA_VERSION}
 # Image URL to use all building/pushing image targets
 CLEAN_IMG ?= ${IMAGE_PREFIX}cleanup:${TEST_INFRA_VERSION}
-#${IMAGE_PREFIX}cleanup_agent:${TEST_INFRA_VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/config/cleanup_agent/cleanup_agent.yaml
+++ b/config/cleanup_agent/cleanup_agent.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: cleanup-agent-manager
     spec:
+      nodeSelector:
+        default-system-pool: "true"
       containers:
       - command:
         image: cleanup_agent:latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      nodeSelector:
+        default-system-pool: "true"
       containers:
       - command:
         - /workspace/bin/controller


### PR DESCRIPTION
This pull request sets a nodeSelector on the controller and cleanup agent. This selector instructs Kubernetes to place them on nodes with a label of "default-system-pool" set to "true". Unfortunately, kustomize does not allow the nodeSelector field to be edited over the command line. Luckily, this design decouples the name of the actual system pool from the release.