### PR TITLE
Log test runner configuration before running tests.

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -46,11 +46,11 @@ func main() {
 		log.Fatalf("Failed to validate concurrency levels: %v", err)
 	}
 
-	log.Printf("annotation key for queue assignment: %s", a)
-	log.Printf("polling interval: %v", p)
-	log.Printf("polling retries: %d", retries)
-	log.Printf("test counts per queue: %v", runner.CountConfigs(configQueueMap))
-	log.Printf("queue concurrency levels: %v", c)
+	log.Printf("Annotation key for queue assignment: %s", a)
+	log.Printf("Polling interval: %v", p)
+	log.Printf("Polling retries: %d", retries)
+	log.Printf("Test counts per queue: %v", runner.CountConfigs(configQueueMap))
+	log.Printf("Queue concurrency levels: %v", c)
 
 	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -30,9 +30,9 @@ func main() {
 
 	flag.Var(&i, "i", "input files containing load test configurations")
 	flag.Var(&c, "c", "concurrency level, in the form [<queue name>:]<concurrency level>")
-	flag.StringVar(&a, "a", "pool", "annotation key to parse for queue assignment")
-	flag.DurationVar(&p, "p", 20*time.Second, "polling interval for load test status")
-	flag.UintVar(&retries, "retries", 2, "Maximum retries in case of communication failure")
+	flag.StringVar(&a, "annotation-key", "pool", "annotation key to parse for queue assignment")
+	flag.DurationVar(&p, "polling-interval", 20*time.Second, "polling interval for load test status")
+	flag.UintVar(&retries, "polling-retries", 2, "Maximum retries in case of communication failure")
 	flag.Parse()
 
 	inputConfigs, err := runner.DecodeFromFiles(i)
@@ -45,6 +45,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to validate concurrency levels: %v", err)
 	}
+
+	log.Printf("annotation key for queue assignment: %s", a)
+	log.Printf("polling interval: %v", p)
+	log.Printf("polling retries: %d", retries)
+	log.Printf("test counts per queue: %v", runner.CountConfigs(configQueueMap))
+	log.Printf("queue concurrency levels: %v", c)
 
 	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries)
 

--- a/tools/runner/queues.go
+++ b/tools/runner/queues.go
@@ -59,3 +59,12 @@ func ValidateConcurrencyLevels(configMap map[string][]*grpcv1.LoadTest, concurre
 	}
 	return nil
 }
+
+// CountConfigs counts the number of configs in each queue.
+func CountConfigs(configMap map[string][]*grpcv1.LoadTest) map[string]int {
+	m := make(map[string]int)
+	for qName, configs := range configMap {
+		m[qName] = len(configs)
+	}
+	return m
+}

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -59,7 +59,9 @@ func (r *Runner) Run(qName string, configs []*grpcv1.LoadTest, concurrencyLevel 
 	n := 0
 	for i, config := range configs {
 		if n < concurrencyLevel {
-			go r.runTest(qName, config, i, done)
+			id := fmt.Sprintf("%-14s %3d", qName, i)
+			log.Printf("[%s] Starting test %d in queue %s", id, i, qName)
+			go r.runTest(id, config, i, done)
 			n++
 			continue
 		}
@@ -74,8 +76,7 @@ func (r *Runner) Run(qName string, configs []*grpcv1.LoadTest, concurrencyLevel 
 }
 
 // runTest creates a single LoadTest and monitors it to completion.
-func (r *Runner) runTest(qName string, config *grpcv1.LoadTest, i int, done chan int) {
-	id := fmt.Sprintf("%-14s %3d", qName, i)
+func (r *Runner) runTest(id string, config *grpcv1.LoadTest, i int, done chan int) {
 	name := nameString(config)
 	var s, status string
 	var retries uint


### PR DESCRIPTION
This change updates the name of optional flags to make them more informative, and also logs queue names, test counts,  concurrency levals, as well as other flag values.

Example:

```
$ ./bin/runner -i ../grpc/loadtest-8core.yaml -i ../grpc/loadtest-32core.yaml -annotation-key pool -c workers-8core:6 -c workers-32core:6 -polling-interval 10s -polling-retries 1
2021/05/12 14:34:35 Annotation key for queue assignment: pool
2021/05/12 14:34:35 Polling interval: 10s
2021/05/12 14:34:35 Polling retries: 1
2021/05/12 14:34:35 Test counts per queue: map[workers-32core:12 workers-8core:12]
2021/05/12 14:34:35 Queue concurrency levels: map[workers-32core:6 workers-8core:6]
```

In addition, this change adds logging for the start of each test, before it is created on the cluster:

```
$ ./bin/runner -i ../grpc/loadtest-8core.yaml -i ../grpc/loadtest-32core.yaml -c workers-8core:4 -c workers-32core:2
2021/05/13 00:06:57 [workers-32core   0] Starting test 0 in queue workers-32core
2021/05/13 00:06:57 [workers-32core   1] Starting test 1 in queue workers-32core
2021/05/13 00:06:57 [workers-8core    0] Starting test 0 in queue workers-8core
2021/05/13 00:06:57 [workers-8core    1] Starting test 1 in queue workers-8core
2021/05/13 00:06:57 [workers-8core    2] Starting test 2 in queue workers-8core
2021/05/13 00:06:57 [workers-8core    3] Starting test 3 in queue workers-8core
2021/05/13 00:06:57 [workers-32core   0] Created test pcastello-manual-go-generic-sync-streaming-ping-pong-secure-workers-32core [pcastello-manual-6d97ceb3-9521-5f25-b34c-c84fd865c798]
```
