### PR TITLE
Make log prefix for tests in test runner more uniform.

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -52,7 +52,7 @@ func main() {
 	log.Printf("Test counts per queue: %v", runner.CountConfigs(configQueueMap))
 	log.Printf("Queue concurrency levels: %v", c)
 
-	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries)
+	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.LogPrefixFmt(configQueueMap), runner.AfterIntervalFunction(p), retries)
 
 	for qName, configs := range configQueueMap {
 		go r.Run(qName, configs, c[qName])

--- a/tools/runner/queues.go
+++ b/tools/runner/queues.go
@@ -68,3 +68,19 @@ func CountConfigs(configMap map[string][]*grpcv1.LoadTest) map[string]int {
 	}
 	return m
 }
+
+// LogPrefixFmt returns a string to format log line prefixes for each test.
+// This string is used to format queue name and test index into a prefix.
+func LogPrefixFmt(configMap map[string][]*grpcv1.LoadTest) string {
+	var queueWidth, indexWidth int
+	for qName, configs := range configMap {
+		if qw := len(qName); qw > queueWidth {
+			queueWidth = qw
+		}
+		if iw := len(fmt.Sprint(len(configs) - 1)); iw > indexWidth {
+			indexWidth = iw
+		}
+	}
+	logPrefixFmt := fmt.Sprintf("[%%-%ds %%%dd] ", queueWidth, indexWidth)
+	return logPrefixFmt
+}


### PR DESCRIPTION
This change moves the definition of the log prefix used for each test into a single location, and makes it consistent for any combination of queue names and test counts.