### PR TITLE
Add LoadTest state information to kubectl get

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -320,7 +320,7 @@ type LoadTestSpec struct {
 // components. If any one component has errored, the load test will be marked in
 // an Errored state, too. This will occur even if the other components are
 // running or succeeded.
-// +kubebuilder:default=Unrecognized
+// +kubebuilder:default=Unknown
 type LoadTestState string
 
 const (
@@ -416,6 +416,8 @@ type LoadTestStatus struct {
 // +kubebuilder:subresource:status
 
 // LoadTest is the Schema for the loadtests API
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type LoadTest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/e2etest.grpc.io_loadtests.yaml
+++ b/config/crd/bases/e2etest.grpc.io_loadtests.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: loadtests.e2etest.grpc.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: e2etest.grpc.io
   names:
     kind: LoadTest


### PR DESCRIPTION
This commit uses fields on the Custom Resource Definition to customize the behavior of the `kubectl get loadtest[s]` command. It now shows the state of the test if it has started or completed. This allows a developer to see the test's progress without having to `kubectl describe` it.