### PR TITLE
Use "php7" language name in defaults and examples.

### DIFF
--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -32,7 +32,7 @@ languages:
     buildImage: "{{ .BuildImagePrefix }}node:{{ .Version }}"
     runImage: "{{ .ImagePrefix }}node:{{ .Version }}"
 
-  - language: php
+  - language: php7
     buildImage: "{{ .BuildImagePrefix }}php:{{ .Version }}"
     runImage: "{{ .ImagePrefix }}php:{{ .Version }}"
 

--- a/config/samples/php7_example_loadtest.yaml
+++ b/config/samples/php7_example_loadtest.yaml
@@ -4,14 +4,14 @@ metadata:
   # Every load test instance must be assigned a unique name on the
   # cluster. There are ways we can circumvent naming clashes, such
   # as using namespaces or dynamically assigning names.
-  name: prebuilt-php-example
+  name: php7-example
 
   # As a custom resource, it behaves like a native kubernetes object.
   # This means that users can perform CRUD operations through the
   # Kubernetes API or kubectl. In addition, it means that the user
   # can set any metadata on it.
   labels:
-    language: php
+    language: php7
 spec:
   # The user can specify servers to use when running tests. The
   # initial version only supports 1 server to limit scope. Servers
@@ -21,17 +21,25 @@ spec:
   # organizing and monitoring a mesh of servers. Therefore, this
   # will likely be expanded in the future.
   servers:
-  - language: php
+  - language: php7
+    clone:
+      repo: https://github.com/grpc/grpc.git
+      gitRef: master
+    build:
+      command: [ "bash", "/build_scripts/build_qps_worker.sh" ]
     run:
-      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
       command: [ "bash", "/run_scripts/run_worker.sh" ]
 
   # Users can specify multiple clients. They are bound by the
   # number of nodes.
   clients:
-  - language: php
+  - language: php7
+    clone:
+      repo: https://github.com/grpc/grpc.git
+      gitRef: master
+    build:
+      command: [ "bash", "/build_scripts/build_qps_worker.sh" ]
     run:
-      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
       command: [ "bash", "/run_scripts/run_worker.sh" ]
 
   # We can optionally specify where to place the results. The

--- a/config/samples/php7_example_loadtest_with_pre_built_workers.yaml
+++ b/config/samples/php7_example_loadtest_with_pre_built_workers.yaml
@@ -4,14 +4,14 @@ metadata:
   # Every load test instance must be assigned a unique name on the
   # cluster. There are ways we can circumvent naming clashes, such
   # as using namespaces or dynamically assigning names.
-  name: php-example
+  name: prebuilt-php7-example
 
   # As a custom resource, it behaves like a native kubernetes object.
   # This means that users can perform CRUD operations through the
   # Kubernetes API or kubectl. In addition, it means that the user
   # can set any metadata on it.
   labels:
-    language: php
+    language: php7
 spec:
   # The user can specify servers to use when running tests. The
   # initial version only supports 1 server to limit scope. Servers
@@ -21,25 +21,17 @@ spec:
   # organizing and monitoring a mesh of servers. Therefore, this
   # will likely be expanded in the future.
   servers:
-  - language: php
-    clone:
-      repo: https://github.com/grpc/grpc.git
-      gitRef: master
-    build:
-      command: [ "bash", "/build_scripts/build_qps_worker.sh" ]
+  - language: php7
     run:
+      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
       command: [ "bash", "/run_scripts/run_worker.sh" ]
 
   # Users can specify multiple clients. They are bound by the
   # number of nodes.
   clients:
-  - language: php
-    clone:
-      repo: https://github.com/grpc/grpc.git
-      gitRef: master
-    build:
-      command: [ "bash", "/build_scripts/build_qps_worker.sh" ]
+  - language: php7
     run:
+      image: ${prebuilt_image_prefix}/php:${prebuilt_image_tag}
       command: [ "bash", "/run_scripts/run_worker.sh" ]
 
   # We can optionally specify where to place the results. The

--- a/tools/prepare_prebuilt_workers/prepare_prebuilt_workers.go
+++ b/tools/prepare_prebuilt_workers/prepare_prebuilt_workers.go
@@ -107,7 +107,7 @@ func main() {
 		split := strings.Split(pair, ":")
 
 		if len(split) != 2 || split[len(split)-1] == "" {
-			log.Fatalf("Input error in language and gitref selection, please follow the format as language:gitref, for example: cxx:<commit-sha>")
+			log.Fatalf("Input error in language and gitref selection, please follow the format as language:gitref, for example: c++:<commit-sha>")
 		}
 
 		lang := split[0]


### PR DESCRIPTION
This change renames the language in the defaults and examples from "php" to "php7", to match the language name in test scenarios. This change requires a new controller release before default images can be used. Tests with prebuilt images are not affected.