### PR TITLE
Fix ruby worker issue in release 0.6.0

### DIFF
--- a/containers/init/build/ruby/build_qps_worker.sh
+++ b/containers/init/build/ruby/build_qps_worker.sh
@@ -19,3 +19,4 @@ export GEM_HOME=/src/workspace/vendor/bundle/
 
 bundle install
 
+rake compile


### PR DESCRIPTION
This is an error found out in the process of release of 0.6.0.
I realized that I accidentally delete rake compile when trying
to improve ruby image.