### PR TITLE
Change the way ready containers find worker pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ uninstall: uninstall-crd uninstall-rbac
 
 # Install CRDs into a cluster
 install-crd: manifests
-	kustomize build config/crd | kubectl apply -f - 
+	kustomize build config/crd | kubectl apply -f -
 
 # Uninstall CRDs from a cluster
 uninstall-crd: manifests

--- a/Makefile
+++ b/Makefile
@@ -65,26 +65,26 @@ delete_prebuilt_workers: $(TOOLSPREREQ)
 	go build $(GOARGS) -o bin/delete_prebuilt_workers tools/delete_prebuilt_workers/delete_prebuilt_workers.go
 
 # Install both CRDs and RBACs
-install: installCRD installRBAC
+install: install-crd install-rbac
 
 # Uninstall both CRDs and RBACs
-uninstall: uninstallCRD uninstallRBAC
+uninstall: uninstall-crd uninstall-rbac
 
 # Install CRDs into a cluster
-installCRD: manifests
+install-crd: manifests
 	kustomize build config/crd | kubectl apply -f - 
 
 # Uninstall CRDs from a cluster
-uninstallCRD: manifests
+uninstall-crd: manifests
 	kustomize build config/crd | kubectl delete -f -
 
 
 # Install RBACs into a cluster
-installRBAC: manifests
+install-rbac: manifests
 	kustomize build config/rbac | kubectl apply -f -
 
 # Uninstall RBACs from a cluster
-uninstallRBAC: manifests
+uninstall-rbac: manifests
 	kustomize build config/rbac | kubectl delete -f -
 
 # Deploy both controller and cleanup_agent to the cluster

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,21 @@ delete_prebuilt_workers: $(TOOLSPREREQ)
 	go build $(GOARGS) -o bin/delete_prebuilt_workers tools/delete_prebuilt_workers/delete_prebuilt_workers.go
 
 # Install CRDs into a cluster
-install: manifests
-	kustomize build config/crd | kubectl apply -f -
+installCRD: manifests
+	kustomize build config/crd | kubectl apply -f - 
 
 # Uninstall CRDs from a cluster
-uninstall: manifests
+uninstallCRD: manifests
 	kustomize build config/crd | kubectl delete -f -
+
+
+# Install RBACs into a cluster
+installRBAC: manifests
+	kustomize build config/rbac | kubectl apply -f -
+
+# Uninstall RBACs from a cluster
+uninstallRBAC: manifests
+	kustomize build config/rbac | kubectl delete -f -
 
 # Deploy both controller and cleanup_agent to the cluster
 deploy: deploy-controller deploy-cleanup-agent

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ prepare_prebuilt_workers: $(TOOLSPREREQ)
 delete_prebuilt_workers: $(TOOLSPREREQ)
 	go build $(GOARGS) -o bin/delete_prebuilt_workers tools/delete_prebuilt_workers/delete_prebuilt_workers.go
 
+# Install both CRDs and RBACs
+install: installCRD installRBAC
+
+# Uninstall both CRDs and RBACs
+uninstall: uninstallCRD uninstallRBAC
+
 # Install CRDs into a cluster
 installCRD: manifests
 	kustomize build config/crd | kubectl apply -f - 

--- a/config/rbac/bindings/component_role_binding.yaml
+++ b/config/rbac/bindings/component_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: component-rolebinding
+  name: component-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pod-viewer-role
+  name: pod_driver_role
 subjects:
 - kind: ServiceAccount
   name: default

--- a/config/rbac/bindings/component_role_binding.yaml
+++ b/config/rbac/bindings/component_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pod_driver_role
+  name: pod-driver-role
 subjects:
 - kind: ServiceAccount
   name: default

--- a/config/rbac/roles/pod_driver_role.yaml
+++ b/config/rbac/roles/pod_driver_role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod_driver_role
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - e2etest.grpc.io
+  resources:
+  - loadtests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - e2etest.grpc.io
+  resources:
+  - loadtests/status
+  verbs:
+  - get

--- a/config/rbac/roles/pod_driver_role.yaml
+++ b/config/rbac/roles/pod_driver_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pod_driver_role
+  name: pod-driver-role
 rules:
 - apiGroups: [""]
   resources:

--- a/containers/init/ready/README.md
+++ b/containers/init/ready/README.md
@@ -1,13 +1,13 @@
 # Ready
 
-Ready is a container that waits for a list of pods within a loadtest to
+Ready is a container that waits for a list of pods within a load test to
 become available. It exits successfully when all worker pods are ready, writing a
 comma-separated list of their IP addresses to a file. It exits unsuccessfully if
 a timeout was exceeded before all pods were ready.
 
 ## Usage
 
-The container relies on command line argument to specify the loadtest's name.
+The container relies on command line argument to specify the load test's name.
 For example,
 
 ```shell

--- a/containers/init/ready/README.md
+++ b/containers/init/ready/README.md
@@ -8,13 +8,12 @@ a timeout was exceeded before all pods were ready.
 ## Usage
 
 The container relies on command line argument to specify the load test's name.
-For example,
+For example,, the following waits for all worker pods which belong to the LoadTest
+named `<LOADTEST_NAME>`:
 
 ```shell
-go run ready.go LOADTEST_NAME
+go run ready.go <LOADTEST_NAME>
 ```
-
-Will wait for all worker pods which belongs to LOADTEST_NAME
 
 Meanwhile, users can set environment variables to override some defaults:
 

--- a/containers/init/ready/README.md
+++ b/containers/init/ready/README.md
@@ -1,25 +1,20 @@
 # Ready
 
-Ready is a container that waits for a list of pods with specific labels to
-become available. It exits successfully when all pods are ready, writing a
+Ready is a container that waits for a list of pods within a loadtest to
+become available. It exits successfully when all worker pods are ready, writing a
 comma-separated list of their IP addresses to a file. It exits unsuccessfully if
 a timeout was exceeded before all pods were ready.
 
 ## Usage
 
-The container relies on command line arguments to specify the labels pods should
-match. These arguments are in the form of `key=value,key2=value2` where commas
-are treated as `AND`s and spaces delineate separate pods. For example,
+The container relies on command line argument to specify the loadtest's name.
+For example,
 
 ```shell
-go run ready.go role=server,proxy=envoy role=client role=client
+go run ready.go LOADTEST_NAME
 ```
 
-Will wait for three pods:
-
-1. pod with labels role=server AND proxy=envoy
-2. pod with label role=client
-3. another pod with label role=client
+Will wait for all worker pods which belongs to LOADTEST_NAME
 
 Meanwhile, users can set environment variables to override some defaults:
 

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -211,7 +211,6 @@ func main() {
 		}
 	}
 
-	kubeConfigFile, _ := os.LookupEnv(KubeConfigEnv)
 	schemebuilder := runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
 		scheme.AddKnownTypes(grpcv1.GroupVersion,
 			&grpcv1.LoadTest{},
@@ -226,8 +225,10 @@ func main() {
 		if err != rest.ErrNotInCluster {
 			log.Fatalf("failed to connect within cluster: %v", err)
 		}
-		if err != nil {
-			log.Fatalf("could not find a home directory for user: %v", err)
+
+		kubeConfigFile, ok := os.LookupEnv(KubeConfigEnv)
+		if !ok {
+			log.Fatalf("could not find kubenetes config file")
 		}
 
 		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigFile)

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -75,7 +75,7 @@ type PodLister interface {
 	List(metav1.ListOptions) (*corev1.PodList, error)
 }
 
-// LoadtestGetter fetch a loadtest with a specific loadtest name.
+// LoadtestGetter fetch a load test with a specific name.
 type LoadtestGetter interface {
 	Get(string, metav1.GetOptions) (*grpcv1.LoadTest, error)
 }
@@ -118,7 +118,8 @@ func findDriverPort(pod *corev1.Pod) int32 {
 	return DefaultDriverPort
 }
 
-// WaitForReadyPods blocks until worker pods belonging to the loadtest are ready.
+// WaitForReadyPods blocks until all worker pods belonging to the load test are
+// ready.
 // It accepts a context, allowing a timeout or deadline to be specified. When
 // all pods are ready, it returns a slice of strings with the IP address and
 // driver port for each matching pod. server pod would come before client pod.

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -25,22 +25,23 @@ import (
 	"strings"
 	"time"
 
+	grpcv1 "github.com/grpc/test-infra/api/v1"
+	grpcclientset "github.com/grpc/test-infra/clientset"
+	"github.com/grpc/test-infra/config"
+	"github.com/grpc/test-infra/status"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/grpc/test-infra/kubehelpers"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // TimeoutEnv is the name of the environment variable that will contain the
 // maximum amount of time to wait for pods to become ready.
 const TimeoutEnv = "READY_TIMEOUT"
-
-// LoadtestUUIDEnv is the name of the environment variable that will contain the
-// loadtest's uuid so that driver could match correct pods.
-const LoadtestUUIDEnv = "LOADTEST_UUID"
 
 // DefaultTimeout specifies the amount of time to wait for ready pods if the
 // environment variable specified by the TimeoutEnv constant is not set.
@@ -74,21 +75,9 @@ type PodLister interface {
 	List(metav1.ListOptions) (*corev1.PodList, error)
 }
 
-// parseSelectors accepts a slice of strings and converts them into Kubernetes
-// selectors. It returns an error if any of the strings is not a valid selector.
-func parseSelectors(sels []string) ([]labels.Selector, error) {
-	var selectors []labels.Selector
-
-	for i, arg := range sels {
-		selector, err := labels.Parse(arg)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse selector #%d (%s): %v", i+1, arg, err)
-		}
-
-		selectors = append(selectors, selector)
-	}
-
-	return selectors, nil
+// LoadtestGetter fetch a loadtest with a specific loadtest name.
+type LoadtestGetter interface {
+	Get(string, metav1.GetOptions) (*grpcv1.LoadTest, error)
 }
 
 // isPodReady returns true if the pod has been assigned an IP address and all of
@@ -129,13 +118,10 @@ func findDriverPort(pod *corev1.Pod) int32 {
 	return DefaultDriverPort
 }
 
-// WaitForReadyPods blocks until pods with matching label selectors are ready.
+// WaitForReadyPods blocks until worker pods belonging to the loadtest are ready.
 // It accepts a context, allowing a timeout or deadline to be specified. When
 // all pods are ready, it returns a slice of strings with the IP address and
-// driver port for each matching pod. The order will match the label selectors.
-//
-// The syntax for the selectors is defined in the Parse function documented at
-// pkg.go.dev/k8s.io/apimachinery/pkg/labels.
+// driver port for each matching pod. server pod would come before client pod.
 //
 // The driver port is determined by searching the pod for a container with a TCP
 // port named "driver". If there is no port named "driver" exposed on any of the
@@ -143,78 +129,73 @@ func findDriverPort(pod *corev1.Pod) int32 {
 //
 // If the timeout is exceeded or there is a problem communicating with the
 // Kubernetes API, an error is returned.
-func WaitForReadyPods(ctx context.Context, pl PodLister, sels []string, UUID string) ([]string, error) {
+func WaitForReadyPods(ctx context.Context, lg LoadtestGetter, pl PodLister, testName string) ([]string, error) {
 	timeoutsEnabled := true
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		timeoutsEnabled = false
 		log.Printf("no timeout is set; this could block forever")
 	}
-
-	selectors, err := parseSelectors(sels)
-	if err != nil {
-		return nil, err
-	}
-
-	var podAddresses []string
-	for range selectors {
-		podAddresses = append(podAddresses, "")
-	}
-
-	matchCount := 0
+	var loadtest *grpcv1.LoadTest
+	var clientPodAddresses []string
+	var serverPodAddresses []string
+	clientMatchCount := 0
+	serverMatchCount := 0
 	matchingPods := make(map[string]bool)
 
 	for {
 		if timeoutsEnabled && time.Now().After(deadline) {
 			return nil, errors.Errorf("deadline exceeded (%v)", deadline)
 		}
-
+		if loadtest == nil {
+			l, err := lg.Get(testName, metav1.GetOptions{})
+			if err != nil {
+				log.Printf("failed to fetch loadtest: %v", err)
+				time.Sleep(pollInterval)
+				continue
+			}
+			loadtest = l
+			for range loadtest.Spec.Clients {
+				clientPodAddresses = append(clientPodAddresses, "")
+			}
+			for range loadtest.Spec.Servers {
+				serverPodAddresses = append(serverPodAddresses, "")
+			}
+		}
 		podList, err := pl.List(metav1.ListOptions{})
 		if err != nil {
 			log.Fatalf("failed to fetch list of pods: %v", err)
 		}
-
-		for _, pod := range podList.Items {
-			if !isPodReady(&pod) {
+		ownedPods := status.PodsForLoadTest(loadtest, podList.Items)
+		for _, pod := range ownedPods {
+			if !isPodReady(pod) {
 				continue
 			}
-
+			if pod.GetLabels()[config.RoleLabel] == config.DriverRole {
+				continue
+			}
 			if _, alreadyMatched := matchingPods[pod.Name]; alreadyMatched {
 				continue
 			}
-
-			for i, selector := range selectors {
-				if podAddresses[i] != "" {
-					continue
-				}
-
-				if selector.Matches(labels.Set(pod.Labels)) {
-					var matched = false
-					for _, owner := range pod.GetOwnerReferences() {
-						if string(owner.UID) == UUID {
-							matched = true
-							break
-						}
-					}
-					if matched {
-						ip := pod.Status.PodIP
-						driverPort := findDriverPort(&pod)
-						podAddresses[i] = fmt.Sprintf("%s:%d", ip, driverPort)
-						matchingPods[pod.Name] = true
-						matchCount++
-						break
-					}
-				}
+			matchingPods[pod.Name] = true
+			ip := pod.Status.PodIP
+			driverPort := findDriverPort(pod)
+			if pod.GetLabels()[config.RoleLabel] == config.ServerRole {
+				serverPodAddresses[serverMatchCount] = fmt.Sprintf("%s:%d", ip, driverPort)
+				serverMatchCount++
+			} else {
+				clientPodAddresses[clientMatchCount] = fmt.Sprintf("%s:%d", ip, driverPort)
+				clientMatchCount++
 			}
 		}
 
-		if matchCount == len(selectors) {
+		if clientMatchCount == len(clientPodAddresses) && serverMatchCount == len(serverPodAddresses) {
 			break
 		}
 
 		time.Sleep(pollInterval)
 	}
-
+	podAddresses := append(serverPodAddresses, clientPodAddresses...)
 	return podAddresses, nil
 }
 
@@ -229,23 +210,44 @@ func main() {
 		}
 	}
 
-	UUID, ok := os.LookupEnv(LoadtestUUIDEnv)
-	if !ok {
-		log.Fatal("fail to get environment variable LOADTEST_UUID")
+	kubeConfigFile, _ := os.LookupEnv(KubeConfigEnv)
+	schemebuilder := runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
+		scheme.AddKnownTypes(grpcv1.GroupVersion,
+			&grpcv1.LoadTest{},
+			&grpcv1.LoadTestList{},
+		)
+		metav1.AddToGroupVersion(scheme, grpcv1.GroupVersion)
+		return nil
+	})
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		if err != rest.ErrNotInCluster {
+			log.Fatalf("failed to connect within cluster: %v", err)
+		}
+		if err != nil {
+			log.Fatalf("could not find a home directory for user: %v", err)
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+		if err != nil {
+			log.Fatalf("failed to construct config for path %q: %v", kubeConfigFile, err)
+		}
 	}
 
-	var clientset kubernetes.Interface
-	kubeConfigFile, ok := os.LookupEnv(KubeConfigEnv)
-	if ok {
-		clientset, err = kubehelpers.ConnectWithConfig(kubeConfigFile)
-		if err != nil {
-			log.Fatalf("failed to read kubeconfig: %v", err)
-		}
-	} else {
-		clientset, err = kubehelpers.ConnectWithinCluster()
-		if err != nil {
-			log.Fatalf("failed to connect with implicit kubeconfig: %v", err)
-		}
+	schemebuilder.AddToScheme(clientgoscheme.Scheme)
+	scheme := clientgoscheme.Scheme
+	types := scheme.AllKnownTypes()
+	_ = types
+
+	grpcClientset, err := grpcclientset.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("failed to create a grpc clientset: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("failed to connect with implicit kubeconfig: %v", err)
 	}
 
 	outputFile := DefaultOutputFile
@@ -256,9 +258,8 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-
 	log.Printf("Waiting for ready pods")
-	podIPs, err := WaitForReadyPods(ctx, clientset.CoreV1().Pods(metav1.NamespaceAll), os.Args[1:], UUID)
+	podIPs, err := WaitForReadyPods(ctx, grpcClientset.LoadTestV1().LoadTests(corev1.NamespaceDefault), clientset.CoreV1().Pods(metav1.NamespaceAll), os.Args[1])
 	if err != nil {
 		log.Fatalf("failed to wait for ready pods: %v", err)
 	}

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -64,10 +64,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			PodList: &corev1.PodList{},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(0, 0),
 		}
-		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		podAddresses, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(BeEmpty())
 	})
@@ -82,10 +82,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(1, 0),
 		}
-		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		_, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -103,11 +103,11 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
 		}
 
-		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		_, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -122,10 +122,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(0, 1),
 		}
-		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		_, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -141,10 +141,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
 		}
-		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		_, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -167,11 +167,11 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 1),
 		}
 
-		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		podAddresses, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(Equal([]string{
 			fmt.Sprintf("%s:%d", serverPod.Status.PodIP, DefaultDriverPort),
@@ -199,11 +199,11 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
 		}
 
-		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		podAddresses, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(Equal([]string{
 			fmt.Sprintf("%s:%d", clientPod.Status.PodIP, DefaultDriverPort),
@@ -220,10 +220,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			PodList:       &corev1.PodList{},
 		}
 
-		loadGetterMock := &LoadtestGetterMock{
+		loadTestGetterMock := &LoadTestGetterMock{
 			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
 		}
-		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
+		_, err := WaitForReadyPods(ctx, loadTestGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -245,14 +245,14 @@ func (plm *PodListerMock) List(opts metav1.ListOptions) (*corev1.PodList, error)
 	return plm.PodList, nil
 }
 
-type LoadtestGetterMock struct {
+type LoadTestGetterMock struct {
 	Loadtest      *grpcv1.LoadTest
 	SleepDuration time.Duration
 	Error         error
 	invocation    int
 }
 
-func (lgm *LoadtestGetterMock) Get(testName string, opts metav1.GetOptions) (*grpcv1.LoadTest, error) {
+func (lgm *LoadTestGetterMock) Get(testName string, opts metav1.GetOptions) (*grpcv1.LoadTest, error) {
 	time.Sleep(lgm.SleepDuration)
 
 	if lgm.Error != nil {

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -23,7 +23,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	grpcv1 "github.com/grpc/test-infra/api/v1"
 	"github.com/grpc/test-infra/config"
 	"github.com/grpc/test-infra/kubehelpers"
 
@@ -35,7 +37,6 @@ var _ = Describe("WaitForReadyPods", func() {
 	var fastDuration time.Duration
 	var slowDuration time.Duration
 
-	var irrelevantPod corev1.Pod
 	var driverPod corev1.Pod
 	var serverPod corev1.Pod
 	var clientPod corev1.Pod
@@ -43,8 +44,6 @@ var _ = Describe("WaitForReadyPods", func() {
 	BeforeEach(func() {
 		fastDuration = 1 * time.Millisecond * timeMultiplier
 		slowDuration = 100 * time.Millisecond * timeMultiplier
-
-		irrelevantPod = corev1.Pod{}
 
 		driverPod = newTestPod("driver")
 		driverRunContainer := kubehelpers.ContainerForName(config.RunContainerName, driverPod.Spec.Containers)
@@ -61,11 +60,14 @@ var _ = Describe("WaitForReadyPods", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{},
 		}
 
-		podAddresses, err := WaitForReadyPods(ctx, mock, []string{})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(0, 0),
+		}
+		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(BeEmpty())
 	})
@@ -73,14 +75,17 @@ var _ = Describe("WaitForReadyPods", func() {
 	It("timeout reached when no matching pods are found", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
 		defer cancel()
-
-		mock := &PodListerMock{
+		clientPod.ObjectMeta.OwnerReferences[0].UID = types.UID("other-test-uid")
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
-				Items: []corev1.Pod{irrelevantPod},
+				Items: []corev1.Pod{clientPod},
 			},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{"hello=anyone-out-there"})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(1, 0),
+		}
+		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -88,7 +93,7 @@ var _ = Describe("WaitForReadyPods", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
 		defer cancel()
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
 				Items: []corev1.Pod{
 					driverPod,
@@ -98,37 +103,29 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{"role=driver", "role=client", "role=client"})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
+		}
+
+		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("timeout reached when pod does not match all labels", func() {
+	It("timeout reached when no ready pod matches", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
 		defer cancel()
 
-		mock := &PodListerMock{
+		serverPod.Status.ContainerStatuses[0].Ready = false
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
-				Items: []corev1.Pod{driverPod},
+				Items: []corev1.Pod{serverPod},
 			},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{"role=driver,loadtest=loadtest-1"})
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("timeout reached when not ready pod matches", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
-		defer cancel()
-
-		driverPod.Status.ContainerStatuses[0].Ready = false
-
-		mock := &PodListerMock{
-			PodList: &corev1.PodList{
-				Items: []corev1.Pod{driverPod},
-			},
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(0, 1),
 		}
-
-		_, err := WaitForReadyPods(ctx, mock, []string{"role=driver"})
+		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -136,7 +133,7 @@ var _ = Describe("WaitForReadyPods", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), slowDuration)
 		defer cancel()
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
 				Items: []corev1.Pod{
 					clientPod,
@@ -144,10 +141,10 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{
-			"role=client",
-			"role=client",
-		})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
+		}
+		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -159,26 +156,24 @@ var _ = Describe("WaitForReadyPods", func() {
 		client2Pod.Name = "client-2"
 		client2Pod.Status.PodIP = "127.0.0.4"
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
 				Items: []corev1.Pod{
 					driverPod,
-					serverPod,
 					clientPod,
 					client2Pod,
+					serverPod,
 				},
 			},
 		}
 
-		podAddresses, err := WaitForReadyPods(ctx, mock, []string{
-			"role=driver",
-			"role=server",
-			"role=client",
-			"role=client",
-		})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 1),
+		}
+
+		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(Equal([]string{
-			fmt.Sprintf("%s:%d", driverPod.Status.PodIP, DefaultDriverPort),
 			fmt.Sprintf("%s:%d", serverPod.Status.PodIP, DefaultDriverPort),
 			fmt.Sprintf("%s:%d", clientPod.Status.PodIP, DefaultDriverPort),
 			fmt.Sprintf("%s:%d", client2Pod.Status.PodIP, DefaultDriverPort),
@@ -195,7 +190,7 @@ var _ = Describe("WaitForReadyPods", func() {
 		client2PodContainer := kubehelpers.ContainerForName(config.RunContainerName, client2Pod.Spec.Containers)
 		client2PodContainer.Ports[0].ContainerPort = customPort
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			PodList: &corev1.PodList{
 				Items: []corev1.Pod{
 					clientPod,
@@ -204,10 +199,11 @@ var _ = Describe("WaitForReadyPods", func() {
 			},
 		}
 
-		podAddresses, err := WaitForReadyPods(ctx, mock, []string{
-			"role=client",
-			"role=client",
-		})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
+		}
+
+		podAddresses, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podAddresses).To(Equal([]string{
 			fmt.Sprintf("%s:%d", clientPod.Status.PodIP, DefaultDriverPort),
@@ -219,12 +215,15 @@ var _ = Describe("WaitForReadyPods", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), fastDuration)
 		defer cancel()
 
-		mock := &PodListerMock{
+		podListerMock := &PodListerMock{
 			SleepDuration: slowDuration,
 			PodList:       &corev1.PodList{},
 		}
 
-		_, err := WaitForReadyPods(ctx, mock, []string{"example"})
+		loadGetterMock := &LoadtestGetterMock{
+			Loadtest: newLoadTestWithMultipleClientsAndServers(2, 0),
+		}
+		_, err := WaitForReadyPods(ctx, loadGetterMock, podListerMock, "test name")
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -244,4 +243,21 @@ func (plm *PodListerMock) List(opts metav1.ListOptions) (*corev1.PodList, error)
 	}
 
 	return plm.PodList, nil
+}
+
+type LoadtestGetterMock struct {
+	Loadtest      *grpcv1.LoadTest
+	SleepDuration time.Duration
+	Error         error
+	invocation    int
+}
+
+func (lgm *LoadtestGetterMock) Get(testName string, opts metav1.GetOptions) (*grpcv1.LoadTest, error) {
+	time.Sleep(lgm.SleepDuration)
+
+	if lgm.Error != nil {
+		return nil, lgm.Error
+	}
+
+	return lgm.Loadtest, nil
 }

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -98,6 +98,10 @@ func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Cont
 				Name:  "READY_TIMEOUT",
 				Value: fmt.Sprintf("%d%s", test.Spec.TimeoutSeconds, "s"),
 			},
+			{
+				Name:  "LOADTEST_UUID",
+				Value: string(test.GetUID()),
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -71,18 +71,7 @@ func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Cont
 	}
 
 	var args []string
-	for _, server := range test.Spec.Servers {
-		args = append(args, fmt.Sprintf("%s=%s,%s=%s",
-			config.RoleLabel, config.ServerRole,
-			config.ComponentNameLabel, *server.Name,
-		))
-	}
-	for _, client := range test.Spec.Clients {
-		args = append(args, fmt.Sprintf("%s=%s,%s=%s",
-			config.RoleLabel, config.ClientRole,
-			config.ComponentNameLabel, *client.Name,
-		))
-	}
+	args = append(args, test.GetName())
 
 	return corev1.Container{
 		Name:    config.ReadyInitContainerName,
@@ -97,10 +86,6 @@ func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Cont
 			{
 				Name:  "READY_TIMEOUT",
 				Value: fmt.Sprintf("%d%s", test.Spec.TimeoutSeconds, "s"),
-			},
-			{
-				Name:  "LOADTEST_UUID",
-				Value: string(test.GetUID()),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Now, the ready container would accept a command line argument to specify a load test name. It would find all worker pod (not driver) owned by the load test and record their ip addresses.