### PR TITLE
Fix segfault when no XML report is generated

### DIFF
--- a/tools/runner/reporter.go
+++ b/tools/runner/reporter.go
@@ -86,6 +86,7 @@ func (r *Reporter) NewTestSuiteReporter(qName string, logPrefixFmt string) *Test
 // TestSuiteReporter manages reports for tests that share a runner queue.
 type TestSuiteReporter struct {
 	testSuite    *junit.TestSuite
+	testCount    int
 	qName        string
 	logPrefixFmt string
 	startTime    time.Time
@@ -126,9 +127,10 @@ func (tsr *TestSuiteReporter) Duration() time.Duration {
 
 // NewTestCaseReporter creates a new reporter instance.
 func (tsr *TestSuiteReporter) NewTestCaseReporter(config *grpcv1.LoadTest) *TestCaseReporter {
-	index := len(tsr.testSuite.Cases)
-	logPrefix := fmt.Sprintf(tsr.logPrefixFmt, tsr.qName, index)
+	index := tsr.testCount
+	tsr.testCount++
 
+	logPrefix := fmt.Sprintf(tsr.logPrefixFmt, tsr.qName, index)
 	caseReporter := &TestCaseReporter{
 		logPrintf: func(format string, v ...interface{}) {
 			log.Printf(logPrefix+format, v...)


### PR DESCRIPTION
The runner can generate JUnit XML reports using the reporter structs. The reporters log to stdout even when reports are not generated. An index uniquely identifies a load test in these logs. In the previous version, the value of this index was determined using the number of known test cases. Unfortunately, this reference is nil when JUnit reports are disabled. This led to a crash.

This commit removes this reference. It adds an integer that is manually incremented to provide a unique index to each test case. This resolves the issue.