### PR TITLE
Make run field optional in driver configuration.

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -161,6 +161,7 @@ type Driver struct {
 
 	// Run describes the run container, which is the runtime of the driver for
 	// the actual test.
+	// +optional
 	Run Run `json:"run"`
 }
 

--- a/config/crd/bases/e2etest.grpc.io_loadtests.yaml
+++ b/config/crd/bases/e2etest.grpc.io_loadtests.yaml
@@ -802,7 +802,6 @@ spec:
                   type: object
               required:
               - language
-              - run
               type: object
             results:
               description: Results configures where the results of the test should

--- a/config/samples/go_example_loadtest.yaml
+++ b/config/samples/go_example_loadtest.yaml
@@ -29,6 +29,9 @@ spec:
     run:
       command:
       - /src/workspace/bin/worker
+  driver:
+    language: cxx
+    name: '0'
   scenariosJSON: |
     {
       "scenarios": {


### PR DESCRIPTION
This commit changes grpcv1.Driver.Run from a required value to
an option value so that the driver's name could be set within
LoadTest configuration yaml file.