### PR TITLE
Add governance and maintainers files.

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,2 @@
+This repository is governed by the gRPC organization's
+[governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+This page lists all active maintainers of this repository. If you were a
+maintainer and would like to add your name to the Emeritus list, please send us
+a PR.
+
+See
+[GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/master/governance.md)
+for governance guidelines and how to become a maintainer. See
+[CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md)
+for general contribution guidelines.
+
+## Maintainers (in alphabetical order)
+
+- [paulosjca](https://github.com/paulosjca), Google LLC
+- [wanlin31](https://github.com/wanlin31), Google LLC
+- [ybbbby](https://github.com/ybbbby), Google LLC
+
+## Emeritus Maintainers (in alphabetical order)
+
+- [codeblooded](https://github.com/codeblooded), Google LLC


### PR DESCRIPTION
Adds missing files to https://github.com/grpc/test-infra repo.

The wording is taken from https://github.com/grpc/grpc.