### PR TITLE
Update driver timeout

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -87,4 +87,4 @@ ENV QPS_WORKERS_FILE=""
 ENV SCENARIOS_FILE="/src/driver/example.json"
 ENV BQ_RESULT_TABLE=""
 
-CMD ["bash", "-c", "timeout --kill-after=$KILL_AFTER $POD_TIMEOUT /src/driver/run.sh"]
+CMD ["bash", "-c", "timeout --kill-after=${KILL_AFTER} ${POD_TIMEOUT} /src/driver/run.sh"]

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -87,4 +87,4 @@ ENV QPS_WORKERS_FILE=""
 ENV SCENARIOS_FILE="/src/driver/example.json"
 ENV BQ_RESULT_TABLE=""
 
-CMD ["/src/driver/run.sh"]
+CMD ["bash", "-c", "timeout --kill-after=$KILL_AFTER $POD_TIMEOUT /src/driver/run.sh"]

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -19,7 +19,7 @@ if [ -n "$QPS_WORKERS_FILE" ]; then
   export QPS_WORKERS=$(cat $QPS_WORKERS_FILE)
 fi
 
-timeout --kill-after=$KILL_AFTER $POD_TIMEOUT /src/code/bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
+/src/code/bazel-bin/test/cpp/qps/qps_json_driver --scenarios_file=$SCENARIOS_FILE \
   --scenario_result_file='scenario_result.json'
 
 /src/code/bazel-bin/test/cpp/qps/qps_json_driver --quit=true


### PR DESCRIPTION
This commit update where the timeout is applied for driver
process. The timeout was wrapped around the driver
process only, which left other process such as uploading 
results to BigQuery unguarded. The timeout is updated
to wrap around the whole process to make sure driver
pod will timeout after given time.  