### PR TITLE
Fix php7 flakiness problem

### DIFF
--- a/containers/init/build/php7/Dockerfile
+++ b/containers/init/build/php7/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install rvm
 RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
   apt-get clean
 
 # Install rvm
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y \
   apt-get clean
 
 # Install rvm
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/containers/runtime/php7/Dockerfile
+++ b/containers/runtime/php7/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install rvm
 RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --keyserver hkp://keys.openpgp.org --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5


### PR DESCRIPTION
Sometimes, we could run into `gpg: keyserver receive failed: No name`. That is because the pool.sks-keyservers.net is no longer maintained. We can switch to hkps://keys.openpgp.org which has been adopted by many open-source projects 