### PR TITLE
Remove unneeded copy from xml report generation.

### DIFF
--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -92,6 +92,8 @@ func main() {
 	reporter.SetEndTime(time.Now())
 
 	if report != nil {
+		report.Finalize()
+
 		outputFile, err := os.Create(o)
 		if err != nil {
 			log.Fatalf("Failed to create output file %q: %v", o, err)


### PR DESCRIPTION
Reports are generated after test cases are completed, so there is no need to create a copy before updating test case counts and writing out the report.

If a `DeepCopy` method is needed, it can be added back later, outside of the `Finalize` and `WriteToStream` methods.