### PR TITLE
save node info to a json file

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -86,6 +86,10 @@ const (
 	// should write all Metadata.
 	ReadyMetadataOutputFile = ReadyMountPath + "/metadata.json"
 
+	// ReadyNodeInfoOutputFile is the name of the file where the ready init container
+	// should write node infomation.
+	ReadyNodeInfoOutputFile = ReadyMountPath + "/node_info.json"
+
 	// ReadyVolumeName is the name of the volume that permits sharing files
 	// between the ready init container and the driver's run container.
 	ReadyVolumeName = "worker-addresses"

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -97,11 +97,15 @@ type PodLister interface {
 type LoadTestGetter interface {
 	Get(context.Context, string, metav1.GetOptions) (*grpcv1.LoadTest, error)
 }
+
+// NodeInfo contain a pod name, pod IP and node name for one worker or driver.
 type NodeInfo struct {
 	Name     string
 	PodIP    string
 	NodeName string
 }
+
+// NodesInfo contain all pods' NodeInfo included in a load test.
 type NodesInfo struct {
 	Driver  NodeInfo
 	Servers []NodeInfo

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -93,12 +93,12 @@ type PodLister interface {
 	List(context.Context, metav1.ListOptions) (*corev1.PodList, error)
 }
 
-// LoadTestGetter fetch a load test with a specific name.
+// LoadTestGetter fetches a load test with a specific name.
 type LoadTestGetter interface {
 	Get(context.Context, string, metav1.GetOptions) (*grpcv1.LoadTest, error)
 }
 
-// NodeInfo contain pod name, pod IP and node name in which the pod reside for one worker or driver.
+// NodeInfo contains pod name, pod IP and node name in which the pod reside for one worker or driver.
 type NodeInfo struct {
 	Name     string
 	PodIP    string

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -72,7 +72,7 @@ const DefaultMetadataOutputFile = "/tmp/metadata.json"
 
 // DefaultNodeInfoOutputFile is the name of the default file where the executable should
 // write the node infomation.
-const DefaultNodeInfoOutputFile = "/tmp/node_info"
+const DefaultNodeInfoOutputFile = "/tmp/node_info.json"
 
 // DefaultDriverPort is the default port for communication between the driver
 // and worker pods. When another port could not be found on a pod, this port is
@@ -348,7 +348,7 @@ func main() {
 
 	nodeInfoFileBody, err := json.Marshal(*nodesInfo)
 	if err != nil {
-		log.Fatalf("failed to marshal node information for loadtest %s: %v", test.Name, err)
+		log.Fatalf("failed to marshal nodes information for loadtest %s: %v", test.Name, err)
 	}
 	ioutil.WriteFile(outputNodeInfoFile, nodeInfoFileBody, 0777)
 }

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -105,7 +105,7 @@ type NodeInfo struct {
 	NodeName string
 }
 
-// NodesInfo contain all pods' NodeInfo included in a load test.
+// NodesInfo contains NodeInfo for all pods included in a load test.
 type NodesInfo struct {
 	Driver  NodeInfo
 	Servers []NodeInfo
@@ -207,7 +207,7 @@ func WaitForReadyPods(ctx context.Context, ltg LoadTestGetter, pl PodLister, tes
 				if !driverMatched && pod.Status.PodIP != "" {
 					nodesInfo.Driver = NodeInfo{
 						Name:     pod.Name,
-						PodIP:    net.JoinHostPort(pod.Status.PodIP, fmt.Sprint(findDriverPort(pod))),
+						PodIP:    pod.Status.PodIP,
 						NodeName: pod.Spec.NodeName,
 					}
 					driverMatched = true
@@ -227,7 +227,7 @@ func WaitForReadyPods(ctx context.Context, ltg LoadTestGetter, pl PodLister, tes
 				serverPodAddresses[serverMatchCount] = net.JoinHostPort(ip, fmt.Sprint(driverPort))
 				nodesInfo.Servers = append(nodesInfo.Servers, NodeInfo{
 					Name:     pod.Name,
-					PodIP:    serverPodAddresses[serverMatchCount],
+					PodIP:    ip,
 					NodeName: pod.Spec.NodeName,
 				})
 				serverMatchCount++
@@ -235,7 +235,7 @@ func WaitForReadyPods(ctx context.Context, ltg LoadTestGetter, pl PodLister, tes
 				clientPodAddresses[clientMatchCount] = net.JoinHostPort(ip, fmt.Sprint(driverPort))
 				nodesInfo.Clients = append(nodesInfo.Clients, NodeInfo{
 					Name:     pod.Name,
-					PodIP:    clientPodAddresses[clientMatchCount],
+					PodIP:    ip,
 					NodeName: pod.Spec.NodeName,
 				})
 				clientMatchCount++

--- a/containers/init/ready/ready.go
+++ b/containers/init/ready/ready.go
@@ -98,7 +98,7 @@ type LoadTestGetter interface {
 	Get(context.Context, string, metav1.GetOptions) (*grpcv1.LoadTest, error)
 }
 
-// NodeInfo contain a pod name, pod IP and node name for one worker or driver.
+// NodeInfo contain pod name, pod IP and node name in which the pod reside for one worker or driver.
 type NodeInfo struct {
 	Name     string
 	PodIP    string

--- a/containers/init/ready/ready_test.go
+++ b/containers/init/ready/ready_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -76,7 +75,7 @@ var _ = Describe("WaitForReadyPods", func() {
 		Expect(*nodesInfo).To(Equal(NodesInfo{
 			Driver: NodeInfo{
 				Name:     driverPod.Name,
-				PodIP:    net.JoinHostPort(driverPod.Status.PodIP, "10000"),
+				PodIP:    driverPod.Status.PodIP,
 				NodeName: driverPod.Spec.NodeName,
 			},
 		}))

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -24,8 +24,12 @@ fi
 
 /src/code/bazel-bin/test/cpp/qps/qps_json_driver --quit=true
 
-if [ -n "${BQ_RESULT_TABLE}" ] && [ -r "${METADATA_OUTPUT_FILE}" ] && [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
-  cp "${METADATA_OUTPUT_FILE}" metadata.json
-  cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
+if [ -n "${BQ_RESULT_TABLE}" ]; then
+  if [ -r "${METADATA_OUTPUT_FILE}" ]; then
+    cp "${METADATA_OUTPUT_FILE}" metadata.json
+  fi
+  if [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
+    cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
+  fi
   python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="${BQ_RESULT_TABLE}"
 fi

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -24,7 +24,8 @@ fi
 
 /src/code/bazel-bin/test/cpp/qps/qps_json_driver --quit=true
 
-if [ -n "${BQ_RESULT_TABLE}" ] && [ -r "${METADATA_OUTPUT_FILE}" ]; then
+if [ -n "${BQ_RESULT_TABLE}" ] && [ -r "${METADATA_OUTPUT_FILE}" ] && [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
   cp "${METADATA_OUTPUT_FILE}" metadata.json
+  cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
   python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="${BQ_RESULT_TABLE}"
 fi

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -91,6 +91,10 @@ func newReadyContainer(defs *config.Defaults, test *grpcv1.LoadTest) corev1.Cont
 				Name:  "METADATA_OUTPUT_FILE",
 				Value: config.ReadyMetadataOutputFile,
 			},
+			{
+				Name:  "NODE_INFO_OUTPUT_FILE",
+				Value: config.ReadyNodeInfoOutputFile,
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -204,6 +208,10 @@ func (pb *PodBuilder) PodForDriver(driver *grpcv1.Driver) (*corev1.Pod, error) {
 		corev1.EnvVar{
 			Name:  "METADATA_OUTPUT_FILE",
 			Value: config.ReadyMetadataOutputFile,
+		},
+		corev1.EnvVar{
+			Name:  "NODE_INFO_OUTPUT_FILE",
+			Value: config.ReadyNodeInfoOutputFile,
 		})
 
 	if results := pb.test.Spec.Results; results != nil {


### PR DESCRIPTION
Driver's ready container would record workers' node info along the way of waiting them. The nodes information would be recorded in node_info.json, which would be saved in BigQuery.