### PR TITLE
Make test names in report TestGrid-friendly.

### DIFF
--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path"
 	"time"
 
 	"github.com/grpc/test-infra/tools/runner"
@@ -30,7 +31,6 @@ import (
 func main() {
 	var i runner.FileNames
 	var o string
-	var xunitSuitesName string
 	var c runner.ConcurrencyLevels
 	var a string
 	var p time.Duration
@@ -38,7 +38,6 @@ func main() {
 
 	flag.Var(&i, "i", "input files containing load test configurations")
 	flag.StringVar(&o, "o", "", "name of the output file for xunit xml report")
-	flag.StringVar(&xunitSuitesName, "xunit-suites-name", "", "name field for testsuites in xunit xml report")
 	flag.Var(&c, "c", "concurrency level, in the form [<queue name>:]<concurrency level>")
 	flag.StringVar(&a, "annotation-key", "pool", "annotation key to parse for queue assignment")
 	flag.DurationVar(&p, "polling-interval", 20*time.Second, "polling interval for load test status")
@@ -66,9 +65,7 @@ func main() {
 
 	logPrefixFmt := runner.LogPrefixFmt(configQueueMap)
 
-	report := xunit.Report{
-		Name: xunitSuitesName,
-	}
+	report := xunit.Report{}
 
 	reporter := runner.NewReporter(&report)
 	reporter.SetStartTime(time.Now())
@@ -79,7 +76,7 @@ func main() {
 	done := make(chan *runner.TestSuiteReporter)
 
 	for qName, configs := range configQueueMap {
-		testSuiteReporter := reporter.NewTestSuiteReporter(qName, logPrefixFmt)
+		testSuiteReporter := reporter.NewTestSuiteReporter(qName, logPrefixFmt, runner.TestCaseNameFromAnnotations("scenario"))
 		testSuiteReporter.SetStartTime(time.Now())
 		go r.Run(ctx, configs, testSuiteReporter, c[qName], done)
 	}
@@ -95,17 +92,34 @@ func main() {
 	report.Finalize()
 
 	if o != "" {
-		outputFile, err := os.Create(o)
-		if err != nil {
-			log.Fatalf("Failed to create output file %q: %v", o, err)
-		}
+		outputPath := xunit.OutputPath(o)
 
-		err = report.WriteToStream(outputFile, xunit.ReportWritingOptions{
-			IndentSize: 2,
-			MaxRetries: 3,
-		})
-		if err != nil {
-			log.Fatalf("Failed to write XML report to output file %q: %v", o, err)
+		for suiteName, suiteReport := range report.Split() {
+			outputFilePath := outputPath(suiteName)
+
+			outputDir := path.Dir(outputFilePath)
+			if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+				log.Fatalf("Failed to create output directory %q: %v", outputDir, err)
+			}
+
+			outputFile, err := os.Create(outputFilePath)
+			if err != nil {
+				log.Fatalf("Failed to create output file %q: %v", outputFilePath, err)
+			}
+
+			err = suiteReport.WriteToStream(outputFile, xunit.ReportWritingOptions{
+				IndentSize: 2,
+				MaxRetries: 3,
+			})
+			if err != nil {
+				log.Fatalf("Failed to write XML report to file %q: %v", outputFilePath, err)
+			}
+
+			if err := outputFile.Close(); err != nil {
+				log.Fatalf("Failed to close output file %q: %v", outputFilePath, err)
+			}
+
+			log.Printf("Wrote XML report to file %q", outputFilePath)
 		}
 	}
 

--- a/tools/runner/flags.go
+++ b/tools/runner/flags.go
@@ -59,7 +59,7 @@ func (c *ConcurrencyLevels) Set(value string) error {
 	cLevel, err := strconv.Atoi(cLevelString)
 	if err != nil {
 		if key == "" {
-			return errors.New("value must be of the form [<queue name>:]<concurrrency level>")
+			return errors.New("value must be of the form [<queue name>:]<concurrency level>")
 		}
 		return fmt.Errorf("concurrency level must be an integer, got %s", cLevelString)
 	}

--- a/tools/runner/xunit/entities.go
+++ b/tools/runner/xunit/entities.go
@@ -55,6 +55,23 @@ func (r *Report) Finalize() {
 	}
 }
 
+// Split separates each test suite into a separate XML report.
+// The reports are returned as a map of test suite names to XML reports, where
+// each report contains a single test suite.
+func (r *Report) Split() map[string]*Report {
+	m := make(map[string]*Report)
+	for _, testSuite := range r.Suites {
+		report := &Report{
+			Name:          testSuite.Name,
+			TimeInSeconds: testSuite.TimeInSeconds,
+			Suites:        []*TestSuite{testSuite},
+		}
+		report.Finalize()
+		m[testSuite.Name] = report
+	}
+	return m
+}
+
 // ReportWritingOptions wraps optional settings for the output report.
 type ReportWritingOptions struct {
 	// Number of spaces which should be used for indentation.

--- a/tools/runner/xunit/strings.go
+++ b/tools/runner/xunit/strings.go
@@ -17,6 +17,7 @@ limitations under the License.
 package xunit
 
 import (
+	"path"
 	"strings"
 	"unicode"
 )
@@ -35,4 +36,25 @@ func Dashify(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// OutputPath returns a function to select different paths to save XML reports.
+// When writing multple reports to files, the resulting function can be used to
+// add a prefix to each file name, and then save it to a directory with the
+// same name as the prefix. This allows tools like test fusion and TestGrid
+// to distinguish tests with the same name in the different reports and display
+// their results correctly.
+func OutputPath(template string) func(string) string {
+	d, f := path.Split(template)
+	if f == "" {
+		return func(prefix string) string {
+			return path.Join(d, prefix, prefix)
+		}
+	}
+	return func(prefix string) string {
+		if prefix != "" {
+			return path.Join(d, prefix, strings.Join([]string{prefix, f}, "_"))
+		}
+		return path.Join(d, f)
+	}
 }


### PR DESCRIPTION
* Change test names in reports to contain only scenario name.
* Save reports for each pool in a separate directory.
* Remove unnecessary flag "xunit-suites-name".