### PR TITLE
Use the message attribute to store error message in xml reports.

### DIFF
--- a/tools/runner/reporter.go
+++ b/tools/runner/reporter.go
@@ -186,7 +186,7 @@ func (tcr *TestCaseReporter) Error(format string, v ...interface{}) {
 		return
 	}
 	tcr.testCase.Errors = append(tcr.testCase.Errors, &xunit.Error{
-		Text: fmt.Sprintf(format, v...),
+		Message: fmt.Sprintf(format, v...),
 	})
 }
 


### PR DESCRIPTION
This eliminates the `Error: No message!`text printed at the top of error messages when displaying results.