### PR TITLE
Get rid of rvm version warning

### DIFF
--- a/containers/init/build/php7/Dockerfile
+++ b/containers/init/build/php7/Dockerfile
@@ -30,12 +30,10 @@ RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A17031138
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
-RUN apt-get update && apt-get install -y procps && apt-get clean
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y procps && apt-get clean
 RUN /bin/bash -l -c "rvm install ruby-2.5"
 RUN /bin/bash -l -c "rvm use --default ruby-2.5"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
-RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 # Install composer

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -31,12 +31,10 @@ RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A17031138
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
-RUN apt-get update && apt-get install -y procps && apt-get clean
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y procps && apt-get clean
 RUN /bin/bash -l -c "rvm install ruby-2.5"
 RUN /bin/bash -l -c "rvm use --default ruby-2.5"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
-RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 # Install composer
@@ -87,11 +85,10 @@ RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A17031138
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y procps && apt-get clean
 RUN /bin/bash -l -c "rvm install ruby-2.5"
 RUN /bin/bash -l -c "rvm use --default ruby-2.5"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
-RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 RUN mkdir -p /execute

--- a/containers/runtime/php7/Dockerfile
+++ b/containers/runtime/php7/Dockerfile
@@ -30,12 +30,10 @@ RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A17031138
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
-RUN apt-get update && apt-get install -y procps && apt-get clean
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y procps && apt-get clean
 RUN /bin/bash -l -c "rvm install ruby-2.5"
 RUN /bin/bash -l -c "rvm use --default ruby-2.5"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
-RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 RUN mkdir /run_scripts


### PR DESCRIPTION
I found that no .bashrc file edits needed, and it could get rid of the warning. Need confirmation from @wanlin31 