### PR TITLE
Add runner flag to delete successful load tests immediately.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -49,7 +49,8 @@ The `runner` tool takes the following options:
   `20s`).
 - `-polling-retries`<br> Maximum retries in case of communication failure
   (default: `2`).
-- `-xunit-suites-name`<br> Name field for testsuites in xunit xml report.
+- `-delete-successful-tests`<br> Delete tests immediately in case of successful
+  termination (default: `false`).
 
 The following example runs tests on two separate queues, specified by the `pool`
 annotation (the most common case in production, where tests run simultaneously

--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -35,6 +35,7 @@ func main() {
 	var a string
 	var p time.Duration
 	var retries uint
+	var deleteSuccessfulTests bool
 
 	flag.Var(&i, "i", "input files containing load test configurations")
 	flag.StringVar(&o, "o", "", "name of the output file for xunit xml report")
@@ -42,6 +43,7 @@ func main() {
 	flag.StringVar(&a, "annotation-key", "pool", "annotation key to parse for queue assignment")
 	flag.DurationVar(&p, "polling-interval", 20*time.Second, "polling interval for load test status")
 	flag.UintVar(&retries, "polling-retries", 2, "Maximum retries in case of communication failure")
+	flag.BoolVar(&deleteSuccessfulTests, "delete-successful-tests", false, "Delete tests immediately in case of successful termination")
 	flag.Parse()
 
 	inputConfigs, err := runner.DecodeFromFiles(i)
@@ -61,7 +63,7 @@ func main() {
 	log.Printf("Test counts per queue: %v", runner.CountConfigs(configQueueMap))
 	log.Printf("Queue concurrency levels: %v", c)
 
-	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries)
+	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests)
 
 	logPrefixFmt := runner.LogPrefixFmt(configQueueMap)
 


### PR DESCRIPTION
If flag `-delete-successful-tests` is set, successful load tests will be deleted immediately, rather than waiting for the expiration of time-to-live.