### PR TITLE
Refactor code to allow saving logs with xml reports.

### DIFF
--- a/tools/runner/xunit/strings.go
+++ b/tools/runner/xunit/strings.go
@@ -39,7 +39,7 @@ func Dashify(s string) string {
 }
 
 // OutputPath returns a function to select different paths to save XML reports.
-// When writing multple reports to files, the resulting function can be used to
+// When writing multiple reports to files, the resulting function can be used to
 // add a prefix to each file name, and then save it to a directory with the
 // same name as the prefix. This allows tools like test fusion and TestGrid
 // to distinguish tests with the same name in the different reports and display


### PR DESCRIPTION
This change moves the logic to create output directories for xml reports before the tests run, so the runner can save logs to the same locations.