### PR TITLE
Configuration to setup prometheus.

### DIFF
--- a/config/prometheus/setup/README.md
+++ b/config/prometheus/setup/README.md
@@ -1,0 +1,10 @@
+The prometheus and servicemonitor configurations are taken from 
+[istio/tools](https://github.com/istio/tools).
+
+Steps to generate the configuration:
+
+* The base configurations and script used came from 
+[tools/perf/istio-install/](https://github.com/istio/tools/tree/master/perf/istio-install#istio-setup)
+* Leave the part related to istio out, only take the portion related 
+to prometheus operator and creating service accounts, clusterroles and clusterrolebinding.
+* Change the namespaces.

--- a/config/prometheus/setup/configuration.yaml
+++ b/config/prometheus/setup/configuration.yaml
@@ -1,0 +1,311 @@
+---
+# Source: base/templates/prometheus-install.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: prometheus
+  labels:
+    app: prometheus
+---
+# Source: base/templates/prometheus-operator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.38.1
+  name: prometheus-operator
+  namespace: prometheus
+---
+# Source: base/templates/prometheus-install.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd
+parameters:
+  type: pd-ssd
+provisioner: kubernetes.io/gce-pd
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+---
+# Source: base/templates/prometheus-install.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-wanlin-prometheus
+  labels:
+    app: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+      - nodes/proxy
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+# Source: base/templates/prometheus-operator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.38.1
+  name: prometheus-operator
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - alertmanagers.monitoring.coreos.com
+      - podmonitors.monitoring.coreos.com
+      - prometheuses.monitoring.coreos.com
+      - prometheusrules.monitoring.coreos.com
+      - servicemonitors.monitoring.coreos.com
+      - thanosrulers.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - alertmanagers/finalizers
+      - prometheuses
+      - prometheuses/finalizers
+      - thanosrulers
+      - thanosrulers/finalizers
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/finalizers
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: base/templates/prometheus-install.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-wanlin-prometheus
+  labels:
+    app: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-wanlin-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: prometheus
+---
+# Source: base/templates/prometheus-operator.yaml
+# From https://raw.githubusercontent.com/coreos/prometheus-operator/v0.38.1/bundle.yaml with namespace replaced
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.38.1
+  name: prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-operator
+    namespace: prometheus
+---
+# Source: base/templates/prometheus-install.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: wanlin-prometheus
+  namespace: prometheus
+  annotations:
+    prometheus.io/scrape: 'true'
+  labels:
+    app: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: http-prometheus
+      protocol: TCP
+      port: 9090
+---
+# Source: base/templates/prometheus-operator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.38.1
+  name: prometheus-operator
+  namespace: prometheus
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+---
+# Source: base/templates/prometheus-operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: v0.38.1
+  name: prometheus-operator
+  namespace: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: v0.38.1
+    spec:
+      containers:
+        - args:
+            - --kubelet-service=kube-system/kubelet
+            - --logtostderr=true
+            - --config-reloader-image=jimmidyson/configmap-reload:v0.3.0
+            - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.38.1
+          image: quay.io/coreos/prometheus-operator:v0.38.1
+          name: prometheus-operator
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        pool: drivers
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: prometheus-operator
+---
+# Source: base/templates/prometheus-install.yaml
+# Source: prometheus-operator/templates/prometheus.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: prometheus
+spec:
+  alerting:
+    alertmanagers:
+      - name: alertmanager-main
+        namespace: prometheus
+        port: web
+  ruleSelector:
+    matchLabels:
+      role: prometheus-example-rules
+      prometheus: prometheus
+  image: "docker.io/prom/prometheus:v2.22.0"
+  version: v2.22.0
+  retention: 72h
+  scrapeInterval: 15s
+  serviceAccountName: prometheus
+  enableAdminAPI: false
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
+  podMonitorNamespaceSelector: {}
+  podMonitorSelector: {}
+  podMetadata:
+    labels:
+      app: prometheus
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            # this is a required field
+            storage: 20Gi
+        storageClassName: ssd

--- a/config/prometheus/setup/configuration.yaml
+++ b/config/prometheus/setup/configuration.yaml
@@ -1,5 +1,5 @@
+
 ---
-# Source: base/templates/prometheus-install.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: prometheus
 ---
-# Source: base/templates/prometheus-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -19,7 +18,6 @@ metadata:
   name: prometheus-operator
   namespace: prometheus
 ---
-# Source: base/templates/prometheus-install.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -30,11 +28,10 @@ provisioner: kubernetes.io/gce-pd
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 ---
-# Source: base/templates/prometheus-install.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-wanlin-prometheus
+  name: prometheus-prometheus
   labels:
     app: prometheus
 rules:
@@ -53,7 +50,6 @@ rules:
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
 ---
-# Source: base/templates/prometheus-operator.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -144,23 +140,21 @@ rules:
       - list
       - watch
 ---
-# Source: base/templates/prometheus-install.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-wanlin-prometheus
+  name: prometheus-prometheus
   labels:
     app: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-wanlin-prometheus
+  name: prometheus-prometheus
 subjects:
   - kind: ServiceAccount
     name: prometheus
     namespace: prometheus
 ---
-# Source: base/templates/prometheus-operator.yaml
 # From https://raw.githubusercontent.com/coreos/prometheus-operator/v0.38.1/bundle.yaml with namespace replaced
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -183,7 +177,7 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: wanlin-prometheus
+  name: prometheus
   namespace: prometheus
   annotations:
     prometheus.io/scrape: 'true'
@@ -197,7 +191,6 @@ spec:
       protocol: TCP
       port: 9090
 ---
-# Source: base/templates/prometheus-operator.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -217,7 +210,6 @@ spec:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
 ---
-# Source: base/templates/prometheus-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -265,8 +257,6 @@ spec:
         runAsUser: 65534
       serviceAccountName: prometheus-operator
 ---
-# Source: base/templates/prometheus-install.yaml
-# Source: prometheus-operator/templates/prometheus.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
@@ -306,6 +296,6 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            # this is a required field
+            # required field
             storage: 20Gi
         storageClassName: ssd

--- a/config/prometheus/setup/servicemonitors.yaml
+++ b/config/prometheus/setup/servicemonitors.yaml
@@ -1,0 +1,66 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet
+  namespace: prometheus
+  labels:
+    monitoring: kubelet-monitor
+    release: wanlin
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 15s
+      port: http-metrics
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 15s
+      relabelings:
+        - sourceLabels: [job]
+          action: replace
+          replacement: kubernetes-cadvisor
+          targetLabel: job
+      metricRelabelings:
+        - action: drop
+          regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+          sourceLabels:
+            - __name__
+      path: /metrics/cadvisor
+      port: http-metrics
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: true
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: prometheus
+  labels:
+    k8s-app: kube-state-metrics
+spec:
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  namespaceSelector:
+    matchNames:
+      - test
+  endpoints:
+    - port: http-metric
+      scheme: http
+      interval: 15s
+      honorLabels: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true

--- a/config/prometheus/setup/servicemonitors.yaml
+++ b/config/prometheus/setup/servicemonitors.yaml
@@ -55,7 +55,7 @@ spec:
       k8s-app: kube-state-metrics
   namespaceSelector:
     matchNames:
-      - test
+      - prometheus
   endpoints:
     - port: http-metric
       scheme: http


### PR DESCRIPTION
This commit takes some of the configuration from Istio/Tools to
set up prometheus and servicemonitor for scraping cpu and memory
usage.

Steps to generate the configuration:
1. Following script [tools/perf/istio-install/setup_istio.sh line 95](https://github.com/istio/tools/blob/22fa6c5a036f9de09d31f8744bdcd728995ffa7d/perf/istio-install/setup_istio.sh#L95)
2. Leave the part related to Istio out, only take the portion related to prometheus operator and creating service accounts, clusterroles and clusterrolebinding.
3. Change the namespaces.