### PR TITLE
Update PHP7 version for OSS benchmarks images.

### DIFF
--- a/containers/init/build/php7/Dockerfile
+++ b/containers/init/build/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7-buster
+FROM php:7.2.34-buster
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
 

--- a/containers/init/build/php7/Dockerfile
+++ b/containers/init/build/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.2.22-buster
+FROM php:7-buster
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
 
@@ -21,12 +21,12 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   build-essential \
   lcov \
-  make && \
+  make \
+  gnugp2 && \
   apt-get clean
 
 # Install rvm
-RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
@@ -37,7 +37,7 @@ RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 # Install composer
-RUN curl -sS https://getcomposer.org/installer | php
+RUN \curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
 RUN mkdir /build_scripts

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir /build_scripts
 ADD build_qps_worker.sh /build_scripts
 RUN /build_scripts/build_qps_worker.sh
 
-FROM php:7-buster
+FROM php:7.2.34-buster
 
 # TODO: when running on kokoro, the "Install" build steps will not be cached
 # since we'll always be on a fresh VM. Re-running this command each

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -38,7 +38,7 @@ RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 # Install composer
-RUN curl -sS https://getcomposer.org/installer | php
+RUN \curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
 RUN mkdir -p /pre

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7-buster
+FROM php:7.2.34-buster
 
 # TODO: when running on kokoro, the "Install" build steps will not be cached
 # since we'll always be on a fresh VM. Re-running this command each

--- a/containers/pre_built_workers/php7/Dockerfile
+++ b/containers/pre_built_workers/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.2.22-buster
+FROM php:7-buster
 
 # TODO: when running on kokoro, the "Install" build steps will not be cached
 # since we'll always be on a fresh VM. Re-running this command each
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
   apt-get clean
 
 # Install rvm
-RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5
@@ -66,7 +66,7 @@ RUN mkdir /build_scripts
 ADD build_qps_worker.sh /build_scripts
 RUN /build_scripts/build_qps_worker.sh
 
-FROM php:7.2.22-buster
+FROM php:7-buster
 
 # TODO: when running on kokoro, the "Install" build steps will not be cached
 # since we'll always be on a fresh VM. Re-running this command each
@@ -81,7 +81,7 @@ RUN apt-get update && apt-get install -y \
   apt-get clean
 
 # Install rvm
-RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/containers/runtime/php7/Dockerfile
+++ b/containers/runtime/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7-buster
+FROM php:7.2.34-buster
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
 

--- a/containers/runtime/php7/Dockerfile
+++ b/containers/runtime/php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.2.22-buster
+FROM php:7-buster
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
 
@@ -21,12 +21,12 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   build-essential \
   lcov \
-  make && \
+  make \
+  gnupg2 && \
   apt-get clean
 
 # Install rvm
-RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5


### PR DESCRIPTION
* Updates PHP7 image versions from php7.2.22-buster to php7.2.34-buster (latest is 7.4.25).
* Updates gpg2 invocation to exclude unused key and remove hardcoded key server specification.
* Proposed as an alternative to #233. 