### PR TITLE
Update dotnet SDK and runtime in C# build

### DIFF
--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -16,7 +16,7 @@ killAfter: {{ .KillAfter }}
 languages:
 - language: csharp
   buildImage: "{{ .BuildImagePrefix }}csharp:{{ .Version }}"
-  runImage: mcr.microsoft.com/dotnet/runtime:2.1
+  runImage: mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim
 
 - language: cxx
   buildImage: l.gcr.io/google/bazel:latest

--- a/containers/init/build/csharp/Dockerfile
+++ b/containers/init/build/csharp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
   apt-get clean
 
 # The prerequisites installed below are heavily inspired by the C# testing image from grpc/grpc
-# https://github.com/grpc/grpc/blob/master/tools/dockerfile/test/csharp_stretch_x64/Dockerfile
+# https://github.com/grpc/grpc/blob/master/tools/dockerfile/test/csharp_buster_x64/Dockerfile
 
 # cmake >=3.6 needed to build grpc_csharp_ext
 RUN apt-get update && apt-get install -y cmake && apt-get clean

--- a/containers/init/build/csharp/build_qps_worker.sh
+++ b/containers/init/build/csharp/build_qps_worker.sh
@@ -23,4 +23,4 @@ make -j8 grpc_csharp_ext
 popd
 
 cd src/csharp
-dotnet publish Grpc.IntegrationTesting.QpsWorker/ -c Release -f netcoreapp2.1 -o ../../../qps_worker
+dotnet publish Grpc.IntegrationTesting.QpsWorker/ -c Release -f netcoreapp3.1 -o ../../qps_worker

--- a/containers/pre_built_workers/csharp/Dockerfile
+++ b/containers/pre_built_workers/csharp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
 
 # TODO: when running on kokoro, this build step will not be cached
 # since we'll always be on a fresh VM. Re-running this command each
@@ -49,7 +49,10 @@ RUN mkdir /build_scripts
 ADD build_qps_worker.sh /build_scripts
 RUN /build_scripts/build_qps_worker.sh
 
-FROM mcr.microsoft.com/dotnet/runtime:2.1
+# Note that the libgrpc_csharp_ext.so library built by the build image
+# needs to binary compatible with the runtime image (e.g. they need to be based off of the same linux distro)
+# Because of that, care needs to be taken to always used a runtime image that's compatible with the build image.
+FROM mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim
 
 RUN mkdir -p /execute
 WORKDIR /execute

--- a/containers/pre_built_workers/csharp/Dockerfile
+++ b/containers/pre_built_workers/csharp/Dockerfile
@@ -50,7 +50,7 @@ ADD build_qps_worker.sh /build_scripts
 RUN /build_scripts/build_qps_worker.sh
 
 # Note that the libgrpc_csharp_ext.so library built by the build image
-# needs to binary compatible with the runtime image (e.g. they need to be based off of the same linux distro)
+# needs to binary-compatible with the runtime image (e.g. they need to be based off of the same linux distro)
 # Because of that, care needs to be taken to always used a runtime image that's compatible with the build image.
 FROM mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim
 

--- a/containers/pre_built_workers/csharp/Dockerfile
+++ b/containers/pre_built_workers/csharp/Dockerfile
@@ -50,7 +50,7 @@ ADD build_qps_worker.sh /build_scripts
 RUN /build_scripts/build_qps_worker.sh
 
 # Note that the libgrpc_csharp_ext.so library built by the build image
-# needs to binary-compatible with the runtime image (e.g. they need to be based off of the same linux distro)
+# needs to be binary-compatible with the runtime image (e.g. they need to be based off of the same linux distro)
 # Because of that, care needs to be taken to always used a runtime image that's compatible with the build image.
 FROM mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim
 

--- a/containers/pre_built_workers/csharp/build_qps_worker.sh
+++ b/containers/pre_built_workers/csharp/build_qps_worker.sh
@@ -23,4 +23,4 @@ make -j8 grpc_csharp_ext
 popd
 
 cd src/csharp
-dotnet publish Grpc.IntegrationTesting.QpsWorker/ -c Release -f netcoreapp2.1 -o ../../../qps_worker
+dotnet publish Grpc.IntegrationTesting.QpsWorker/ -c Release -f netcoreapp3.1 -o ../../qps_worker


### PR DESCRIPTION
This will be needed for https://github.com/grpc/grpc/pull/27966,
but since the build definitions for C# live in two repositories (grpc/grpc and grpc/test-infra), it's difficult to change the C# build atomically and cleanly.

The current plan is that once both PRs are approved, I'll merge them in short succession.