### PR TITLE
Add pod names to properties

### DIFF
--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -147,7 +147,7 @@ func (r *Runner) runTest(ctx context.Context, config *grpcv1.LoadTest, reporter 
 			}
 			reporter.AddProperty("name", loadTest.Name)
 			for pod := range podToPathMap {
-				propertyKey := "pod." + pod.ObjectMeta.Labels["loadtest-role"] + ".name"
+				propertyKey := "pod." + strings.TrimPrefix(pod.Name, loadTest.Name+"-") + ".name"
 				reporter.AddProperty(propertyKey, pod.Name)
 			}
 

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -141,11 +141,15 @@ func (r *Runner) runTest(ctx context.Context, config *grpcv1.LoadTest, reporter 
 		status = statusString(config)
 		switch {
 		case loadTest.Status.State.IsTerminated():
-			_, err := r.logSaver.SavePodLogs(ctx, loadTest, outputDir)
+			podToPathMap, err := r.logSaver.SavePodLogs(ctx, loadTest, outputDir)
 			if err != nil {
 				reporter.Error("Could not save pod logs: %s", err)
 			}
 			reporter.AddProperty("name", loadTest.Name)
+			for pod := range podToPathMap {
+				propertyKey := "pod." + pod.ObjectMeta.Labels["loadtest-role"] + ".name"
+				reporter.AddProperty(propertyKey, pod.Name)
+			}
 
 			if status != "Succeeded" {
 				reporter.Error("Test failed with reason %q: %v", loadTest.Status.Reason, loadTest.Status.Message)

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -141,16 +141,14 @@ func (r *Runner) runTest(ctx context.Context, config *grpcv1.LoadTest, reporter 
 		status = statusString(config)
 		switch {
 		case loadTest.Status.State.IsTerminated():
-			podToPathMap, err := r.logSaver.SavePodLogs(ctx, loadTest, outputDir)
+			savedLogs, err := r.logSaver.SavePodLogs(ctx, loadTest, outputDir)
 			if err != nil {
 				reporter.Error("Could not save pod logs: %s", err)
 			}
 			reporter.AddProperty("name", loadTest.Name)
-			for pod := range podToPathMap {
-				propertyKey := "pod." + strings.TrimPrefix(pod.Name, loadTest.Name+"-") + ".name"
-				reporter.AddProperty(propertyKey, pod.Name)
+			for property, value := range savedLogs.GenerateProperties(loadTest) {
+				reporter.AddProperty(property, value)
 			}
-
 			if status != "Succeeded" {
 				reporter.Error("Test failed with reason %q: %v", loadTest.Status.Reason, loadTest.Status.Message)
 			} else {


### PR DESCRIPTION
Sample output:
```
<testsuites name="" tests="1" errors="0" time="181.396307675">
  <testsuite id="0" name="" tests="1" errors="0" time="181.396307675">
    <testcase name="java-generic-async-streaming-ping-pong-secure" time="181.396193717">
      <properties>
        <property name="name" value="brandonpaiz-pod-test-010"></property>
        <property name="pod.client-0.name" value="brandonpaiz-pod-test-010-client-0"></property>
        <property name="pod.driver-0.name" value="brandonpaiz-pod-test-010-driver-0"></property>
        <property name="pod.server-0.name" value="brandonpaiz-pod-test-010-server-0"></property>
      </properties>
    </testcase>
  </testsuite>
</testsuites>
```
This is in preparation to add `pod.client.url` / `pod.driver.url` / `pod.server.url` properties