### PR TITLE
Add bootstrap file for gRPC test client

### DIFF
--- a/containers/runtime/gRPC_bootstrap/bootstrap.json
+++ b/containers/runtime/gRPC_bootstrap/bootstrap.json
@@ -1,0 +1,18 @@
+{
+    "xds_servers": [
+      {
+        "server_uri": "localhost:18000",
+        "channel_creds": [
+          {
+            "type": "insecure"
+          }
+        ],
+        "server_features": [
+          "xds_v3"
+        ]
+      }
+    ],
+    "node": {
+      "id": "test_id"
+    }
+}


### PR DESCRIPTION
This commit adds the bootstrap.json file. This file is required for gRPC client to be configured by xds server.