### PR TITLE
Fix postgres table name cache issue

### DIFF
--- a/dashboard/postgres_replicator/transfer.go
+++ b/dashboard/postgres_replicator/transfer.go
@@ -143,12 +143,15 @@ func (t *Transfer) convertSchema(bqSchema *BigQuerySchema) (*PostgresSchema, err
 }
 
 func (t *Transfer) prepareTable(tableName string, pgSchema *PostgresSchema) error {
-	tableExists := t.pg.TableExists(tableName)
+	tableExists, err := t.pg.TableExists(tableName)
+	if err != nil {
+		return err
+	}
 	if tableExists {
 		return nil
 	}
 
-	err := t.pg.CreateTableFromSchema(tableName, pgSchema)
+	err = t.pg.CreateTableFromSchema(tableName, pgSchema)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, the library would cache the table names at the start of the process. If a table was created during a transfer, subsequent runs would query the cache and think that the table didn't exist and try to recreate the table, causing an error. One possible fix would be to add the new table name to the cache after creating a table, but it's possible that other unrelated processes are modifying the database. The fix here is to just remove the cache, because it has limited benefit anyway.