### PR TITLE
Add fake listener port for api_listener

### DIFF
--- a/containers/runtime/xds/config/config.go
+++ b/containers/runtime/xds/config/config.go
@@ -226,9 +226,7 @@ func (cr *customResource) UnmarshalJSON(data []byte) error {
 		if err := anypb.UnmarshalTo(&a, &parsedListener, proto.UnmarshalOptions{}); err != nil {
 			log.Fatalf("failed to unmarshal %v resource: %v", resource.ListenerType, err)
 		}
-		// once apiserver is set the socket address can no longer be set, but empty address
-		// will fail the validation. TODO: @wanlin31 to figure out a better way
-		if err := parsedListener.ValidateAll(); parsedListener.ApiListener == nil && err != nil {
+		if err := parsedListener.ValidateAll(); err != nil {
 			log.Fatalf("failed to validate the parsed %v: %v", resource.ListenerType, err)
 		}
 		cr.Resource = &parsedListener

--- a/containers/runtime/xds/config/default_config.json
+++ b/containers/runtime/xds/config/default_config.json
@@ -139,6 +139,12 @@
           "Resource": {
             "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
             "name": "default_testGrpcListenerName",
+            "address": {
+              "socketAddress": {
+                "address": "0.0.0.0",
+                "portValue": 10001
+              }
+            },
             "filterChains": [
               {
                 "filters": [


### PR DESCRIPTION
This commit adds a fake listener port for api_listener, this
listener is used only by proxyless client. Adding the fake
 address and port helps to avoid validation failure.