### PR TITLE
Dashboard fixes

### DIFF
--- a/dashboard/config/grafana/dashboards/default/home.json
+++ b/dashboard/config/grafana/dashboards/default/home.json
@@ -482,7 +482,7 @@
     },
     {
       "datasource": "Postgres",
-      "description": "Language comparison of streaming ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone) when running language-specific clients against a C++ server. Secure connection is used.",
+      "description": "Language comparison of streaming ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4064,5 +4064,5 @@
   "timezone": "browser",
   "title": "gRPC Performance Multi-language on GKE (@upstream/master)",
   "uid": "18sWlbd7z",
-  "version": 3
+  "version": 7
 }

--- a/dashboard/config/grafana/dashboards/default/home.json
+++ b/dashboard/config/grafana/dashboards/default/home.json
@@ -18,48 +18,14 @@
   "links": [],
   "panels": [
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Language comparison of unary ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -72,12 +38,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -90,19 +50,6 @@
               {
                 "id": "displayName",
                 "value": "C#"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "palette-classic"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -115,13 +62,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -134,13 +74,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -153,13 +86,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -172,13 +98,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -196,25 +115,73 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:374",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:383",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:388",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:393",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:398",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:403",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -247,54 +214,58 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure ping pong median latency - Language comparison (in microsec)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:126",
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:127",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Language comparison of unary ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone) when running language-specific clients against a C++ server. Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -307,13 +278,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -326,13 +290,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -345,12 +302,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -363,13 +314,6 @@
               {
                 "id": "displayName",
                 "value": "C#"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -382,13 +326,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -401,13 +338,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -425,25 +355,73 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 4,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:919",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:924",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:929",
+          "alias": "PHP Sync (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:934",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:939",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:944",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -475,54 +453,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure ping pong median latency - Language-specific clients against C++ server (in microsec)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "μs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Language comparison of streaming ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -535,13 +515,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -554,13 +527,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -573,13 +539,6 @@
               {
                 "id": "displayName",
                 "value": "C#"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -592,13 +551,6 @@
               {
                 "id": "displayName",
                 "value": "PHP 7 (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -611,13 +563,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -642,12 +587,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -660,13 +599,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -679,37 +611,88 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 8,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -741,54 +724,58 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure ping pong median latency (in microsec)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1707",
+          "format": "μs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1708",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
-      "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate 8core VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "QPS",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -801,13 +788,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -820,13 +800,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -839,13 +812,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -858,13 +824,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -877,12 +836,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -895,13 +848,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -914,13 +860,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -931,13 +870,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -945,25 +877,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 0,
         "y": 27
       },
+      "hiddenSeries": false,
       "id": 26,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:3474",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:3479",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:3484",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:3489",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:3494",
+          "alias": "PHP Sync (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:3499",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:3504",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:3509",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -995,54 +985,58 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure throughput QPS (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3544",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3545",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Server CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -1055,13 +1049,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1074,13 +1061,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1093,13 +1073,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1112,13 +1085,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1131,12 +1097,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1149,13 +1109,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1168,13 +1121,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1185,13 +1131,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -1199,25 +1138,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 27
       },
+      "hiddenSeries": false,
       "id": 13,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -1249,54 +1246,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure server CPU (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Client CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -1309,13 +1308,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1328,13 +1320,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1347,13 +1332,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1366,13 +1344,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1385,12 +1356,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1403,13 +1368,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1422,13 +1380,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1439,13 +1390,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -1453,25 +1397,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 27
       },
+      "hiddenSeries": false,
       "id": 14,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -1503,54 +1505,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure client CPU (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Throughput as streaming ping-pong operations per second between two GKE nodes in the same cluster (each node resides on a separate 8core VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "QPS",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -1563,13 +1567,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1582,13 +1579,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1601,13 +1591,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1620,13 +1603,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1639,12 +1615,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1657,13 +1627,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1676,13 +1639,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1693,13 +1649,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -1707,25 +1656,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 0,
         "y": 36
       },
+      "hiddenSeries": false,
       "id": 6,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -1757,54 +1764,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure throughput QPS (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Server CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -1817,13 +1826,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1836,13 +1838,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1855,13 +1850,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1874,13 +1862,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1893,12 +1874,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1911,13 +1886,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1930,13 +1898,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -1947,13 +1908,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -1961,25 +1915,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 36
       },
+      "hiddenSeries": false,
       "id": 19,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -2011,54 +2023,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure server CPU (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Client CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -2071,13 +2085,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2090,13 +2097,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2109,13 +2109,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2128,13 +2121,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2147,12 +2133,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2165,13 +2145,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2184,13 +2157,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2201,13 +2167,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -2215,25 +2174,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 36
       },
+      "hiddenSeries": false,
       "id": 20,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -2265,54 +2282,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure client CPU (8 core client to 8 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "QPS",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -2325,13 +2344,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2344,13 +2356,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2363,13 +2368,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2382,13 +2380,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2401,12 +2392,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2419,13 +2404,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2438,13 +2416,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2455,13 +2426,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -2469,25 +2433,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 0,
         "y": 45
       },
+      "hiddenSeries": false,
       "id": 15,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -2519,54 +2541,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure throughput QPS (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Server CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -2579,13 +2603,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2598,13 +2615,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2617,13 +2627,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2636,13 +2639,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2655,12 +2651,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2673,13 +2663,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2692,13 +2675,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2709,13 +2685,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -2723,25 +2692,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 45
       },
+      "hiddenSeries": false,
       "id": 21,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -2773,54 +2800,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure server CPU (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Client CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -2833,13 +2862,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2852,13 +2874,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2871,13 +2886,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2890,13 +2898,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2909,12 +2910,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2927,13 +2922,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2946,13 +2934,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -2963,13 +2944,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -2977,25 +2951,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 45
       },
+      "hiddenSeries": false,
       "id": 17,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -3027,54 +3059,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Unary secure client CPU (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Throughput as streaming ping-pong operations per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "QPS",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 4,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -3087,13 +3121,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3106,13 +3133,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3125,13 +3145,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3144,13 +3157,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3163,12 +3169,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3181,13 +3181,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3200,13 +3193,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3217,13 +3203,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -3231,25 +3210,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 0,
         "y": 54
       },
+      "hiddenSeries": false,
       "id": 22,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -3281,54 +3318,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure throughput QPS (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Server CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -3341,13 +3380,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3360,13 +3392,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3379,13 +3404,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3398,13 +3416,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3417,12 +3428,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3435,13 +3440,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3454,13 +3452,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3471,13 +3462,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -3485,25 +3469,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 54
       },
+      "hiddenSeries": false,
       "id": 23,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -3535,54 +3577,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure server CPU (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "Client CPU",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -3595,13 +3639,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3614,13 +3651,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3633,13 +3663,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3652,13 +3675,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3671,12 +3687,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3689,13 +3699,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3708,13 +3711,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3725,13 +3721,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -3739,25 +3728,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 54
       },
+      "hiddenSeries": false,
       "id": 24,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -3789,54 +3836,56 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Streaming secure client CPU (32 core client to 32 core server)",
-      "type": "timeseries"
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Postgres",
       "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate VM, but both VMs are located in the same compute zone). Secure connection is used. Both request & response are 1MB large.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "QPS",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": [
@@ -3849,13 +3898,6 @@
               {
                 "id": "displayName",
                 "value": "Python"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3868,13 +3910,6 @@
               {
                 "id": "displayName",
                 "value": "Ruby"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3887,13 +3922,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf php)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3906,13 +3934,6 @@
               {
                 "id": "displayName",
                 "value": "PHP Sync (protobuf c)"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-purple",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3925,12 +3946,6 @@
               {
                 "id": "displayName",
                 "value": "C++"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3943,13 +3958,6 @@
               {
                 "id": "displayName",
                 "value": "Go"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#67cfde",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3962,13 +3970,6 @@
               {
                 "id": "displayName",
                 "value": "Java"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
               }
             ]
           },
@@ -3979,13 +3980,6 @@
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
                 "id": "displayName",
                 "value": "C#"
               }
@@ -3993,25 +3987,83 @@
           }
         ]
       },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 63
       },
+      "hiddenSeries": false,
       "id": 25,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1754",
+          "alias": "C++",
+          "color": "rgb(115, 105, 105)"
+        },
+        {
+          "$$hashKey": "object:1759",
+          "alias": "C#",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:1764",
+          "alias": "Go",
+          "color": "#67cfde"
+        },
+        {
+          "$$hashKey": "object:1791",
+          "alias": "Java",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:1796",
+          "alias": "PHP 7 (protobuf php)",
+          "color": "#DEB6F2"
+        },
+        {
+          "$$hashKey": "object:1823",
+          "alias": "PHP Sync (protobuf c)",
+          "color": "#8F3BB8"
+        },
+        {
+          "$$hashKey": "object:1877",
+          "alias": "Python",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:1882",
+          "alias": "Ruby",
+          "color": "#F2495C"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
@@ -4043,10 +4095,46 @@
           ]
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Unary secure throughput QPS (8 core client to 8 core server)",
-      "type": "timeseries"
+      "title": "Unary secure throughput QPS with 1MB message (8 core client to 8 core server)",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -4064,5 +4152,5 @@
   "timezone": "browser",
   "title": "gRPC Performance Multi-language on GKE (@upstream/master)",
   "uid": "18sWlbd7z",
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
1. Convert all charts to type 'graph' instead of 'time series'. This was making it hard to mouseover individual datapoints
2. Add "with 1MB message" to last chart
3. Fixed the description for "Unary secure throughput QPS (8 core client to 8 core server)". It mentioned 32 core, changed to 8.
4. Removed "clients against a C++ server" from chart description where needed