### PR TITLE
Rename run images flag in configuration generator.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,19 +214,15 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+##@ Tools
+
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
-# Downloading kustomize with go get is deprecated, and go install is currently
-# failing. The definition below can be uncommented once this issue is fixed:
-# https://github.com/kubernetes-sigs/kustomize/issues/3618
-# KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
-# kustomize: ## Download kustomize locally if necessary.
-# 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
-KUSTOMIZE = kustomize
-kustomize:
-	@[ -f "$(shell which $@)" ] || (echo "tool not found: $@"; exit 1)
+KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
+kustomize: ## Download kustomize locally if necessary.
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ all-tools: runner prepare_prebuilt_workers delete_prebuilt_workers
 # http://linuxcommand.org/lc3_adv_awk.php
 
 help: ## Display this help.
-	@awk 'BEGIN (FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n") /^[a-zA-Z_0-9-]+:.*?##/ ( printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 ) /^##@/ ( printf "\n\033[1m%s\033[0m\n", substr($$0, 5) ) ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Version tag for all images
-TEST_INFRA_VERSION ?= "latest"
+TEST_INFRA_VERSION ?= latest
 
 # Version of the gRPC driver
-DRIVER_VERSION ?= "master"
+DRIVER_VERSION ?= master
 
-# Prefix for all images used as clone and ready containers, enabling use with registries
-# other than DockerHub
+# Prefix for all images used as clone and ready containers, enabling use with
+# registries other than DockerHub
 INIT_IMAGE_PREFIX ?= ""
 
 # Prefix for all images used as build containers, enabling use with registries
@@ -14,10 +14,10 @@ BUILD_IMAGE_PREFIX ?= ""
 
 # Prefix for all images used as runtime containers, enabling use with registries
 # other than DockerHub
-IMAGE_PREFIX ?= ""
+RUN_IMAGE_PREFIX ?= ""
 
 # Image URL to use all building/pushing image targets
-CONTROLLER_IMG ?= ${IMAGE_PREFIX}controller:${TEST_INFRA_VERSION}
+CONTROLLER_IMG ?= $(RUN_IMAGE_PREFIX)controller:$(TEST_INFRA_VERSION)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
@@ -55,7 +55,7 @@ all-tools: runner prepare_prebuilt_workers delete_prebuilt_workers
 # http://linuxcommand.org/lc3_adv_awk.php
 
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN (FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n") /^[a-zA-Z_0-9-]+:.*?##/ ( printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 ) /^##@/ ( printf "\n\033[1m%s\033[0m\n", substr($$0, 5) ) ' $(MAKEFILE_LIST)
 
 ##@ Development
 
@@ -73,9 +73,9 @@ vet: ## Run go vet against code.
 
 ENVTEST_ASSETS_DIR = $(PROJECT_DIR)/testbin
 test: manifests generate fmt vet ## Run tests.
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out -race -v
+	mkdir -p $(ENVTEST_ASSETS_DIR)
+	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out -race -v
 
 ##@ Build executables
 
@@ -96,98 +96,98 @@ delete_prebuilt_workers: fmt vet ## Build the delete_prebuilt_workers tool binar
 all-images: clone-image controller-image csharp-build-image cxx-image driver-image go-image java-image node-build-image node-image php7-build-image php7-image python-image ready-image ruby-build-image ruby-image ## Build all container images.
 
 clone-image: ## Build the clone init container image.
-	docker build -t ${INIT_IMAGE_PREFIX}clone:${TEST_INFRA_VERSION} containers/init/clone
+	docker build -t $(INIT_IMAGE_PREFIX)clone:$(TEST_INFRA_VERSION) containers/init/clone
 
 controller-image: ## Build the load test controller container image.
-	docker build -t ${CONTROLLER_IMG} -f containers/runtime/controller/Dockerfile .
+	docker build -t $(CONTROLLER_IMG) -f containers/runtime/controller/Dockerfile .
 
 csharp-build-image: ## Build the C# build-time container image.
-	docker build -t ${BUILD_IMAGE_PREFIX}csharp:${TEST_INFRA_VERSION} containers/init/build/csharp
+	docker build -t $(BUILD_IMAGE_PREFIX)csharp:$(TEST_INFRA_VERSION) containers/init/build/csharp
 
 cxx-image: ## Build the C++ test runtime container image.
-	docker build -t ${IMAGE_PREFIX}cxx:${TEST_INFRA_VERSION} containers/runtime/cxx
+	docker build -t $(RUN_IMAGE_PREFIX)cxx:$(TEST_INFRA_VERSION) containers/runtime/cxx
 
 driver-image: ## Build the driver container image.
-	docker build --build-arg GITREF=${DRIVER_VERSION} --build-arg BREAK_CACHE="$(date +%Y%m%d%H%M%S)" -t ${IMAGE_PREFIX}driver:${TEST_INFRA_VERSION} containers/runtime/driver
+	docker build --build-arg GITREF=$(DRIVER_VERSION) --build-arg BREAK_CACHE="$(date +%Y%m%d%H%M%S)" -t $(RUN_IMAGE_PREFIX)driver:$(TEST_INFRA_VERSION) containers/runtime/driver
 
 go-image: ## Build the Go test runtime container image.
-	docker build -t ${IMAGE_PREFIX}go:${TEST_INFRA_VERSION} containers/runtime/go
+	docker build -t $(RUN_IMAGE_PREFIX)go:$(TEST_INFRA_VERSION) containers/runtime/go
 
 java-image: ## Build the Java test runtime container image.
-	docker build -t ${IMAGE_PREFIX}java:${TEST_INFRA_VERSION} containers/runtime/java
+	docker build -t $(RUN_IMAGE_PREFIX)java:$(TEST_INFRA_VERSION) containers/runtime/java
 
 node-build-image: ## Build the Node.js build image
-	docker build -t ${BUILD_IMAGE_PREFIX}node:${TEST_INFRA_VERSION} containers/init/build/node
+	docker build -t $(BUILD_IMAGE_PREFIX)node:$(TEST_INFRA_VERSION) containers/init/build/node
 
 node-image: ## Build the Node.js test runtime container image.
-	docker build -t ${IMAGE_PREFIX}node:${TEST_INFRA_VERSION} containers/runtime/node
+	docker build -t $(RUN_IMAGE_PREFIX)node:$(TEST_INFRA_VERSION) containers/runtime/node
 
 php7-build-image: ## Build the PHP7 build-time container image.
-	docker build -t ${BUILD_IMAGE_PREFIX}php7:${TEST_INFRA_VERSION} containers/init/build/php7
+	docker build -t $(BUILD_IMAGE_PREFIX)php7:$(TEST_INFRA_VERSION) containers/init/build/php7
 
 php7-image: ## Build the PHP7 test runtime container image.
-	docker build -t ${IMAGE_PREFIX}php7:${TEST_INFRA_VERSION} containers/runtime/php7
+	docker build -t $(RUN_IMAGE_PREFIX)php7:$(TEST_INFRA_VERSION) containers/runtime/php7
 
 python-image: ## Build the Python test runtime container image.
-	docker build -t ${IMAGE_PREFIX}python:${TEST_INFRA_VERSION} containers/runtime/python
+	docker build -t $(RUN_IMAGE_PREFIX)python:$(TEST_INFRA_VERSION) containers/runtime/python
 
 ready-image: ## Build the ready init container image.
-	docker build -t ${INIT_IMAGE_PREFIX}ready:${TEST_INFRA_VERSION} -f containers/init/ready/Dockerfile .
+	docker build -t $(INIT_IMAGE_PREFIX)ready:$(TEST_INFRA_VERSION) -f containers/init/ready/Dockerfile .
 
 ruby-build-image: ## Build the Ruby build-time container image.
-	docker build -t ${BUILD_IMAGE_PREFIX}ruby:${TEST_INFRA_VERSION} containers/init/build/ruby
+	docker build -t $(BUILD_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION) containers/init/build/ruby
 
 ruby-image: ## Build the Ruby test runtime container image.
-	docker build -t ${IMAGE_PREFIX}ruby:${TEST_INFRA_VERSION} containers/runtime/ruby
+	docker build -t $(RUN_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION) containers/runtime/ruby
 
 ##@ Publish container images
 
 push-all-images: push-clone-image push-controller-image push-csharp-build-image push-cxx-image push-driver-image push-go-image push-java-image push-node-build-image push-node-image push-php7-build-image push-php7-image push-python-image push-ready-image push-ruby-build-image push-ruby-image ## Push all container images to a registry.
 
 push-clone-image: ## Push the clone init container image to a registry.
-	docker push ${INIT_IMAGE_PREFIX}clone:${TEST_INFRA_VERSION}
+	docker push $(INIT_IMAGE_PREFIX)clone:$(TEST_INFRA_VERSION)
 
 push-controller-image: ## Push the load test controller container image to a registry.
-	docker push ${CONTROLLER_IMG}
+	docker push $(CONTROLLER_IMG)
 
 push-csharp-build-image: ## Push the C# build-time container image to a registry.
-	docker push ${BUILD_IMAGE_PREFIX}csharp:${TEST_INFRA_VERSION}
+	docker push $(BUILD_IMAGE_PREFIX)csharp:$(TEST_INFRA_VERSION)
 
 push-cxx-image: ## Push the C++ test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}cxx:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)cxx:$(TEST_INFRA_VERSION)
 
 push-driver-image: ## Push the driver container image to a registry.
-	docker push ${IMAGE_PREFIX}driver:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)driver:$(TEST_INFRA_VERSION)
 
 push-go-image: ## Push the Go test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}go:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)go:$(TEST_INFRA_VERSION)
 
 push-java-image: ## Push the Java test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}java:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)java:$(TEST_INFRA_VERSION)
 
 push-node-build-image: ## Push the Node.js build image to a docker registry
-	docker push ${BUILD_IMAGE_PREFIX}node:${TEST_INFRA_VERSION}
+	docker push $(BUILD_IMAGE_PREFIX)node:$(TEST_INFRA_VERSION)
 
 push-node-image: ## Push the Node.js test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}node:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)node:$(TEST_INFRA_VERSION)
 
 push-php7-build-image: ## Push the PHP7 build-time container image to a registry.
-	docker push ${BUILD_IMAGE_PREFIX}php7:${TEST_INFRA_VERSION}
+	docker push $(BUILD_IMAGE_PREFIX)php7:$(TEST_INFRA_VERSION)
 
 push-php7-image: ## Push the PHP7 test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}php7:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)php7:$(TEST_INFRA_VERSION)
 
 push-python-image: ## Push the Python test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}python:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)python:$(TEST_INFRA_VERSION)
 
 push-ready-image: ## Push the ready init container image to a registry.
-	docker push ${INIT_IMAGE_PREFIX}ready:${TEST_INFRA_VERSION}
+	docker push $(INIT_IMAGE_PREFIX)ready:$(TEST_INFRA_VERSION)
 
 push-ruby-build-image: ## Push the Ruby build-time container image to a registry.
-	docker push ${BUILD_IMAGE_PREFIX}ruby:${TEST_INFRA_VERSION}
+	docker push $(BUILD_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION)
 
 push-ruby-image: ## Push the Ruby test runtime container image to a registry.
-	docker push ${IMAGE_PREFIX}ruby:${TEST_INFRA_VERSION}
+	docker push $(RUN_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION)
 
 ##@ Deployment
 
@@ -208,7 +208,7 @@ uninstall-rbac: manifests kustomize ## Uninstall RBACs from the K8s cluster spec
 	$(KUSTOMIZE) build config/rbac | kubectl delete --ignore-not-found=true -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(CONTROLLER_IMG)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/config/cmd/configure.go
+++ b/config/cmd/configure.go
@@ -40,8 +40,8 @@ import (
 type DefaultsData struct {
 	Version          string
 	InitImagePrefix  string
-	ImagePrefix      string
 	BuildImagePrefix string
+	RunImagePrefix   string
 	KillAfter        float64
 }
 
@@ -84,10 +84,10 @@ init container images.`)
 This -build-image-prefix flag allows a specific prefix to apply to all
 build container images.`)
 
-	flag.StringVar(&data.ImagePrefix, "image-prefix", "", `prefix to append to container images (optional)
+	flag.StringVar(&data.RunImagePrefix, "run-image-prefix", "", `prefix to append to container images (optional)
 
-This -image-prefix flag allows a specific prefix to apply to all
-container images that are not used as init containers.`)
+This -run-image-prefix flag allows a specific prefix to apply to all
+run container images.`)
 
 	flag.BoolVar(&validate, "validate", true, "validate the output configuration for correctness")
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -9,7 +9,7 @@ cloneImage: "{{ .InitImagePrefix }}clone:{{ .Version }}"
 
 readyImage: "{{ .InitImagePrefix }}ready:{{ .Version }}"
 
-driverImage: "{{ .ImagePrefix }}driver:{{ .Version }}"
+driverImage: "{{ .RunImagePrefix }}driver:{{ .Version }}"
 
 killAfter: {{ .KillAfter }}
 
@@ -19,37 +19,37 @@ languages:
   runImage: mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim
 
 - language: cxx
-  buildImage: l.gcr.io/google/bazel:latest
-  runImage: "{{ .ImagePrefix }}cxx:{{ .Version }}"
+  buildImage: l.gcr.io/google/bazel:3.5.0
+  runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
   buildImage: golang:1.16
-  runImage: "{{ .ImagePrefix }}go:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}go:{{ .Version }}"
 
 - language: java
   buildImage: gradle:jdk8
-  runImage: "{{ .ImagePrefix }}java:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}java:{{ .Version }}"
 
 - language: node
   buildImage: "{{ .BuildImagePrefix }}node:{{ .Version }}"
-  runImage: "{{ .ImagePrefix }}node:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}node:{{ .Version }}"
 
 - language: php7
   buildImage: "{{ .BuildImagePrefix }}php7:{{ .Version }}"
-  runImage: "{{ .ImagePrefix }}php7:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}php7:{{ .Version }}"
 
 - language: php7_protobuf_c
   buildImage: "{{ .BuildImagePrefix }}php7:{{ .Version }}"
-  runImage: "{{ .ImagePrefix }}php7:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}php7:{{ .Version }}"
 
 - language: python
-  buildImage: l.gcr.io/google/bazel:latest
-  runImage: "{{ .ImagePrefix }}python:{{ .Version }}"
+  buildImage: l.gcr.io/google/bazel:3.5.0
+  runImage: "{{ .RunImagePrefix }}python:{{ .Version }}"
 
 - language: python_asyncio
-  buildImage: l.gcr.io/google/bazel:latest
-  runImage: "{{ .ImagePrefix }}python:{{ .Version }}"
+  buildImage: l.gcr.io/google/bazel:3.5.0
+  runImage: "{{ .RunImagePrefix }}python:{{ .Version }}"
 
 - language: ruby
   buildImage: "{{ .BuildImagePrefix }}ruby:{{ .Version }}"
-  runImage: "{{ .ImagePrefix }}ruby:{{ .Version }}"
+  runImage: "{{ .RunImagePrefix }}ruby:{{ .Version }}"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/grpc-testing/e2etest/runtime/controller
-  newTag: v0.7.2-kb3.3
+  newName: controller
+  newTag: v1.x.x

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       nodeSelector:
         default-system-pool: "true"
-      containers:
       # securityContext:
       #   runAsNonRoot: true
       containers:


### PR DESCRIPTION
This includes two changes:

- Rename the flag `-image-prefix` to `-run-image-prefix`, to match `-init-image-prefix` and `build-image-prefix`.
- Pin the latest bazel image version in default configuration to `3.5.0` instead of just `latest`.
- Update Makefile to use RUN_IMAGE_PREFIX and fix format to be more consistent.