### PR TITLE
Update kustomize version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,8 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+##@ Tools
+
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)

--- a/Makefile
+++ b/Makefile
@@ -218,15 +218,9 @@ CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
-# Downloading kustomize with go get is deprecated, and go install is currently
-# failing. The definition below can be uncommented once this issue is fixed:
-# https://github.com/kubernetes-sigs/kustomize/issues/3618
-# KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
-# kustomize: ## Download kustomize locally if necessary.
-# 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
-KUSTOMIZE = kustomize
-kustomize:
-	@[ -f "$(shell which $@)" ] || (echo "tool not found: $@"; exit 1)
+KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
+kustomize: ## Download kustomize locally if necessary.
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/grpc-testing/e2etest/runtime/controller
+  newName: controller
   newTag: v1.0.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: controller
-  newTag: v1.0.0
+  newTag: v1.x.x

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: gcr.io/grpc-testing/e2etest/runtime/controller
-  newTag: v0.7.2-kb3.3
+  newTag: v1.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       nodeSelector:
         default-system-pool: "true"
-      containers:
       # securityContext:
       #   runAsNonRoot: true
       containers:


### PR DESCRIPTION
Version 4.5.2 is not affected by https://github.com/kubernetes-sigs/kustomize/issues/3618.