### PR TITLE
Update podbuilder for multiple run container

### DIFF
--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -251,6 +251,21 @@ var _ = Describe("Defaults", func() {
 				Expect(driver.Run[0].Image).To(Equal(defaults.DriverImage))
 			})
 
+			It("sets run container if the run container is nil", func() {
+				driver.Run = nil
+				err := defaults.SetLoadTestDefaults(loadtest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(driver.Run[0].Name).To(Equal("main"))
+			})
+
+			It("doesn't override the name of the first run container if set", func() {
+				err := defaults.SetLoadTestDefaults(loadtest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(driver.Run[0].Name).To(Equal(loadtest.Spec.Driver.Run[0].Name))
+			})
+
 			It("does not error if run container image cannot be inferred but is set", func() {
 				image := "example-image"
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -163,6 +163,7 @@ func newLoadTest() *grpcv1.LoadTest {
 				Language: "cxx",
 				Pool:     optional.StringPtr("drivers"),
 				Run: []corev1.Container{{
+					Name:  config.RunContainerName,
 					Image: "gcr.io/grpc-test-example/driver:v1",
 				}},
 			},
@@ -182,6 +183,7 @@ func newLoadTest() *grpcv1.LoadTest {
 						Args:    []string{"build", "-o", "server", "./server/main.go"},
 					},
 					Run: []corev1.Container{{
+						Name:    config.RunContainerName,
 						Image:   "gcr.io/grpc-test-example/go:v1",
 						Command: []string{"./server"},
 						Args:    []string{"-verbose"},
@@ -204,6 +206,7 @@ func newLoadTest() *grpcv1.LoadTest {
 						Args:    []string{"build", "-o", "client", "./client/main.go"},
 					},
 					Run: []corev1.Container{{
+						Name:    config.RunContainerName,
 						Image:   "gcr.io/grpc-test-example/go:v1",
 						Command: []string{"./client"},
 						Args:    []string{"-verbose"},

--- a/podbuilder/suite_test.go
+++ b/podbuilder/suite_test.go
@@ -145,6 +145,7 @@ func newLoadTest() *grpcv1.LoadTest {
 				Language: "cxx",
 				Pool:     &driverPool,
 				Run: []corev1.Container{{
+					Name:  config.RunContainerName,
 					Image: driverImage,
 				}},
 			},
@@ -165,6 +166,7 @@ func newLoadTest() *grpcv1.LoadTest {
 						Args:    buildArgs,
 					},
 					Run: []corev1.Container{{
+						Name:    config.RunContainerName,
 						Image:   runImage,
 						Command: runCommand,
 						Args:    serverRunArgs,
@@ -188,9 +190,16 @@ func newLoadTest() *grpcv1.LoadTest {
 						Args:    buildArgs,
 					},
 					Run: []corev1.Container{{
+						Name:    config.RunContainerName,
 						Image:   runImage,
 						Command: runCommand,
 						Args:    clientRunArgs,
+					}, {
+						Name:          "xdsServer",
+						Image:         "xds-image",
+						Command:       []string{"xds-command"},
+						Args:          []string{"xds-args"},
+						LivenessProbe: &corev1.Probe{},
 					}},
 				},
 			},


### PR DESCRIPTION
This commit updates the podbuilder package to accept multiple run
containers. The podbuilder adds the WorkingDir and VolumeMounts
for the main (the first run) container and ENV for all run
containers.