### PR TITLE
Add pre-built image for grpc-dotnet

### DIFF
--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
+
+RUN mkdir -p /pre
+WORKDIR /pre
+
+ARG REPOSITORY=grpc/grpc-dotnet
+ARG GITREF=master
+# when BREAK_CACHE arg is set to a random value (e.g. by "--build-arg BREAK_CACHE=$(uuidgen)"),
+# it makes sure the docker cache breaks at this command, and all the following
+# commands in this Dockerfile will be forced to re-run on each build.
+# This is important to ensure we always clone the repository even if "GITREF" stays unchanged
+# (important e.g. when GITREF=master, when the clone command could get cached and
+# we'd end up with a stale repository).
+ARG BREAK_CACHE
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git checkout $GITREF
+RUN git submodule update --init
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
+# Build standalone build of qps worker, put output into qps_worker directory.
+RUN dotnet publish -c Release -o qps_worker perf/benchmarkapps/QpsWorker/
+
+# Note that the libgrpc_csharp_ext.so library built by the build image
+# needs to be binary-compatible with the runtime image (e.g. they need to be based off of the same linux distro)
+# Because of that, care needs to be taken to always used a runtime image that's compatible with the build image.
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+
+RUN mkdir -p /execute
+WORKDIR /execute
+COPY --from=0 /pre/qps_worker /execute/qps_worker
+COPY --from=0 /pre/GRPC_GIT_COMMIT.txt /execute/GRPC_GIT_COMMIT.txt
+
+CMD ["bash"]

--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -38,9 +38,8 @@ RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 # Build standalone build of qps worker, put output into qps_worker directory.
 RUN dotnet publish -c Release -o qps_worker perf/benchmarkapps/QpsWorker/
 
-# Note that the libgrpc_csharp_ext.so library built by the build image
-# needs to be binary-compatible with the runtime image (e.g. they need to be based off of the same linux distro)
-# Because of that, care needs to be taken to always used a runtime image that's compatible with the build image.
+# Note that the QpsWorker built by "dotnet publish" in the previous step needs to be runnable
+# with the runtime image below.
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 
 RUN mkdir -p /execute


### PR DESCRIPTION
Adds the Dockerfile for "prebuilt" version of grpc-dotnet qps worker.