### PR TITLE
Add prometheus query to driver's run container.

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -83,6 +83,7 @@ RUN pip3 install \
   oauth2client \
   google-auth-oauthlib \
   tabulate \
+  py-dateutil \
   pyasn1_modules==0.2.2 \
   pyasn1==0.4.2 \
   six==1.15.0

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -35,6 +35,12 @@ if [ -n "${BQ_RESULT_TABLE}" ]; then
   fi
   if [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
     cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
+    if [ -n "${SERVER_TARGET_OVERRIDE}" ]; then
+      python3 /src/code/tools/run_tests/performance/prometheus.py \
+        --url=http://prometheus.prometheus.svc.cluster.local:9090 \
+        --pod_type=clients --container_name=main \
+        --container_name=sidecar
+    fi
   fi
   python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="${BQ_RESULT_TABLE}"
 fi


### PR DESCRIPTION
This commit asks the driver to run Prometheus query to obtain
cpu and memory data when running a PSM test. Currently a PSM test
is observed when SERVER_TARGET_OVERRIDE environment variable is
not empty.

In the future, running the query script would depend on if there are 
Prometheus service running.

This PR has to be merged after https://github.com/grpc/grpc/pull/29057 
and https://github.com/grpc/grpc/pull/29197.