### PR TITLE
Add PSM template examples for PHP, Ruby, Python, Cxx, CSharp, Node

### DIFF
--- a/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
@@ -5,37 +5,32 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: csharp_protobuf_async_unary_ping_pong
+    uniquifier: proxied
   labels:
-    language: java
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-ping-pong-proxied
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +46,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,17 +60,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "csharp_protobuf_async_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +83,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,8 +93,9 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "ASYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -99,37 +103,29 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
@@ -5,32 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: csharp_protobuf_async_unary_ping_pong
     uniquifier: proxyless
   labels:
-    language: java
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-ping-pong-proxyless
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -58,17 +56,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "csharp_protobuf_async_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +79,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,8 +89,9 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "ASYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -99,37 +99,29 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
@@ -5,37 +5,35 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: cpp_generic_async_streaming_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-cpp-generic-async-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +49,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,11 +63,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "cpp_generic_async_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,6 +97,7 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -107,29 +114,31 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
@@ -5,32 +5,33 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: cpp_generic_async_streaming_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-cpp-generic-async-streaming-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -58,11 +59,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "cpp_generic_async_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,6 +93,7 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -107,29 +110,31 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/go_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_generic_sync_streaming_ping_pong_secure
+    scenario: go_generic_sync_streaming_ping_pong_insecure
     uniquifier: proxied
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-generic-sync-streaming-ping-pong
+  name: psm-examples-go-generic-sync-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
@@ -34,11 +34,6 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
     - args:
       - -default-config-path 
@@ -68,7 +63,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_generic_sync_streaming_ping_pong_secure",
+        "name": "go_generic_sync_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_generic_sync_streaming_ping_pong_secure
+    scenario: go_generic_sync_streaming_ping_pong_insecure
     uniquifier: proxyless
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-generic-sync-streaming-ping-pong
+  name: psm-examples-go-generic-sync-streaming-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
@@ -35,10 +35,6 @@ spec:
       command:
       - bash
       env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
       name: main
@@ -63,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_generic_sync_streaming_ping_pong_secure",
+        "name": "go_generic_sync_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/java_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_secure
-    uniquifier: proxyless
+    scenario: java_generic_async_streaming_ping_pong_insecure
+    uniquifier: proxied
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong
+  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
@@ -34,10 +34,6 @@ spec:
       command:
       - bash
       env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
       name: main
@@ -69,7 +65,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_secure",
+        "name": "java_generic_async_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/node_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxied.yaml
@@ -5,37 +5,32 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: node_to_node_generic_async_streaming_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: node
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-node-to-node-generic-async-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +46,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,11 +60,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "node_to_node_generic_async_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,6 +94,7 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -107,29 +111,27 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
@@ -5,32 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: node_to_node_generic_async_streaming_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: node
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-node-to-node-generic-async-streaming-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -58,11 +56,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "node_to_node_generic_async_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,6 +90,7 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -107,29 +107,27 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
@@ -5,37 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: php7
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-sync-unary-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: php7
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -44,13 +38,20 @@ spec:
       - containers/runtime/xds-server/bootstrap.json
       command:
       - main
-      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      image: gcr.io/grpc-testing/e2etest/runtime/xds-server:v1.2.0-pre.1
       livenessProbe:
         initialDelaySeconds: 30
         periodSeconds: 5
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: gcr.io/grpc-testing/e2etest/runtime/side-car:v1.2.0-pre.1
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,17 +59,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +82,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,7 +92,8 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -99,37 +102,33 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
@@ -5,32 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: php7
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-sync-unary-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: php7
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        /run_scripts/run_worker.sh
       command:
       - bash
       env:
@@ -58,17 +55,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +78,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,7 +88,8 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -99,37 +98,33 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
@@ -5,37 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-sync-unary-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +45,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,17 +59,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +82,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,7 +92,8 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -99,37 +102,33 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
@@ -5,32 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-sync-unary-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
       env:
@@ -58,17 +55,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -80,7 +78,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,7 +88,8 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
           "async_server_threads": 1,
           "server_processes": 0,
           "threads_per_cq": 0,
@@ -99,37 +98,33 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/python_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxied.yaml
@@ -5,37 +5,36 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: python_generic_sync_streaming_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: python
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-python-generic-sync-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +50,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,11 +64,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "python_generic_sync_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,7 +98,8 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -107,29 +115,31 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/python_example_loadtest_proxyess.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxyess.yaml
@@ -5,32 +5,34 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: python_generic_sync_streaming_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: python
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-python-generic-sync-streaming-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -58,11 +60,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "python_generic_sync_streaming_ping_pong_insecure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -91,7 +94,8 @@ spec:
         },
         "server_config": {
           "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -107,29 +111,31 @@ spec:
             }
           }
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
       args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - gradle
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
@@ -5,37 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
-    uniquifier: proxyless
+    scenario: ruby_protobuf_sync_streaming_ping_pong_insecure
+    uniquifier: proxied
   labels:
-    language: java
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-ruby-protobuf-sync-streaming-ping-pong-insecure-proxied
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path 
@@ -51,6 +45,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000 
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -58,11 +59,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "ruby_protobuf_sync_streaming_ping_pong",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -80,7 +82,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,8 +92,9 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -99,37 +102,28 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
@@ -5,34 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_insecure
+    scenario: ruby_protobuf_sync_streaming_ping_pong_insecure
     uniquifier: proxyless
   labels:
-    language: java
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong-insecure-proxyless
+  name: psm-examples-ruby-protobuf-sync-streaming-ping-pong-insecure-proxyless
 spec:
   clients:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
-      command:
-      - bash
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
@@ -58,11 +53,12 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_insecure",
+        "name": "ruby_protobuf_sync_streaming_ping_pong",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "ASYNC_CLIENT",
+          "client_type": "SYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
           "client_channels": 1,
           "async_client_threads": 1,
@@ -80,7 +76,7 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
+            "simple_params": {
               "req_size": 0,
               "resp_size": 0
             }
@@ -90,8 +86,9 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "SYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 0,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -99,37 +96,28 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }
   servers:
   - build:
-      args:
-      - -PskipAndroid=true
-      - -PskipCodegen=true
-      - :grpc-benchmarks:installDist
       command:
-      - gradle
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-java.git
-    language: java
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /run_scripts/run_worker.sh
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main


### PR DESCRIPTION
This add PSM example templates for more supported languages, such as PHP, Ruby, Python, Cxx, CSharp, Node.

This PR also fixed type in the existing Java and Go examples by explicitly adding `insecure` in the load test names and the scenario names. Prior they were incorrectly marked as secured even the security_parameter for both client and server are removed.