### PR TITLE
fix postgres replicator logger

### DIFF
--- a/dashboard/postgres_replicator/logger.go
+++ b/dashboard/postgres_replicator/logger.go
@@ -20,5 +20,5 @@ func NewLogger(tableName string) *Logger {
 
 // Errorf adds an "Error: " prefix to the format string
 func (l *Logger) Errorf(format string, v ...interface{}) {
-	l.Printf("Error: " + format)
+	l.Printf(fmt.Sprintf("Error: %s", format), v...)
 }


### PR DESCRIPTION
Format strings were not printing properly