### PR TITLE
Add nodeSelector for prometheus.

### DIFF
--- a/config/prometheus/install-prometheus.yaml
+++ b/config/prometheus/install-prometheus.yaml
@@ -98,6 +98,8 @@ spec:
   serviceMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
+  nodeSelector:
+    pool: system
   podMetadata:
     labels:
       app: prometheus


### PR DESCRIPTION
This commit add nodeSelector for Prometheus to make sure Prometheus instance is always scheduled on system node.