### PR TITLE
Add all psm related examples.

### DIFF
--- a/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: csharp
     prefix: psm-examples
-  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxied.yaml
@@ -5,38 +5,32 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +46,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +113,23 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
@@ -5,33 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +109,23 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/csharp_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: csharp
     prefix: psm-examples
-  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -56,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: cxx
     prefix: psm-examples
-  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -63,7 +63,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
@@ -5,38 +5,35 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +49,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +63,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +118,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: cxx
     prefix: psm-examples
-  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
@@ -5,33 +5,33 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +114,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/go_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_generic_sync_streaming_ping_pong_secure
+    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxied
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-generic-sync-streaming-ping-pong
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
@@ -34,15 +34,10 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
     - args:
-      - -default-config-path 
-      - containers/runtime/xds-server/config/default_config.json 
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
       - -path-to-bootstrap
       - containers/runtime/xds-server/bootstrap.json
       command:
@@ -59,7 +54,7 @@ spec:
         initialDelaySeconds: 30
         periodSeconds: 5
         tcpSocket:
-          port: 10000 
+          port: 10000
       name: sidecar
   driver:
     language: cxx
@@ -68,17 +63,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_generic_sync_streaming_ping_pong_secure",
+        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
-          "client_type": "SYNC_CLIENT",
+          "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
-          "client_channels": 1,
+          "client_channels": 8,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -90,18 +86,21 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
+            "simple_params": {
+              "req_size": 1024,
+              "resp_size": 1024
             }
           },
           "load_params": {
-            "closed_loop": {}
+            "poisson": {
+              "offered_load": 5000
+            }
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "ASYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 16,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -109,13 +108,7 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
         "warmup_seconds": 5,
         "benchmark_seconds": 30
@@ -145,8 +138,8 @@ spec:
       - bash
       env:
       - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
+        value: '99'
+      - name: GRPC_GO_LOG_SEVERITY_LEVEL
         value: info
       name: main
   timeoutSeconds: 900

--- a/config/samples/templates/psm/go_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -63,7 +63,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -136,11 +136,6 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -132,11 +132,6 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/java_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_secure
-    uniquifier: proxyless
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
@@ -34,16 +34,12 @@ spec:
       command:
       - bash
       env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
       name: main
     - args:
-      - -default-config-path 
-      - containers/runtime/xds-server/config/default_config.json 
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
       - -path-to-bootstrap
       - containers/runtime/xds-server/bootstrap.json
       command:
@@ -69,17 +65,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_secure",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
-          "client_channels": 1,
+          "client_channels": 8,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -91,18 +88,21 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
+            "simple_params": {
+              "req_size": 1024,
+              "resp_size": 1024
             }
           },
           "load_params": {
-            "closed_loop": {}
+            "poisson": {
+              "offered_load": 5000
+            }
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "ASYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 16,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -110,15 +110,9 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/java_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -65,7 +65,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,7 +112,7 @@ spec:
             }
           ]
         },
-        "warmup_seconds": 5,
+        "warmup_seconds": 15,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -58,7 +58,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -105,7 +105,7 @@ spec:
             }
           ]
         },
-        "warmup_seconds": 5,
+        "warmup_seconds": 15,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: java_generic_async_streaming_ping_pong_secure
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-generic-async-streaming-ping-pong
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
@@ -34,16 +34,12 @@ spec:
       command:
       - bash
       env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: "99"
-      - name:  GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
       name: main
     - args:
-      - -default-config-path 
-      - containers/runtime/xds-server/config/default_config.json 
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
       - -path-to-bootstrap
       - containers/runtime/xds-server/bootstrap.json
       command:
@@ -62,17 +58,18 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_generic_async_streaming_ping_pong_secure",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
           "client_type": "ASYNC_CLIENT",
+          "security_params": null,
           "outstanding_rpcs_per_channel": 1,
-          "client_channels": 1,
+          "client_channels": 8,
           "async_client_threads": 1,
           "client_processes": 0,
           "threads_per_cq": 0,
-          "rpc_type": "STREAMING",
+          "rpc_type": "UNARY",
           "histogram_params": {
             "resolution": 0.01,
             "max_possible": 60000000000.0
@@ -84,18 +81,21 @@ spec:
             }
           ],
           "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
+            "simple_params": {
+              "req_size": 1024,
+              "resp_size": 1024
             }
           },
           "load_params": {
-            "closed_loop": {}
+            "poisson": {
+              "offered_load": 5000
+            }
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
-          "async_server_threads": 1,
+          "server_type": "ASYNC_SERVER",
+          "security_params": null,
+          "async_server_threads": 16,
           "server_processes": 0,
           "threads_per_cq": 0,
           "channel_args": [
@@ -103,15 +103,9 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "bytebuf_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
-        "warmup_seconds": 15,
+        "warmup_seconds": 5,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/node_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxied.yaml
@@ -5,38 +5,32 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: node
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +46,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +113,23 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/node_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: node
     prefix: psm-examples
-  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
@@ -5,33 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: node
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +109,23 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: node
     prefix: psm-examples
-  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -56,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: php7
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: php7
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: php7
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -45,13 +38,20 @@ spec:
       - containers/runtime/xds-server/bootstrap.json
       command:
       - main
-      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      image: gcr.io/grpc-testing/e2etest/runtime/xds-server:v1.2.0-pre.1
       livenessProbe:
         initialDelaySeconds: 30
         periodSeconds: 5
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: gcr.io/grpc-testing/e2etest/runtime/side-car:v1.2.0-pre.1
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +114,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: php7
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -55,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
@@ -5,33 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: php7
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: php7
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_worker.sh
       command:
       - bash
       env:
@@ -59,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +110,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +45,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +114,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
@@ -5,33 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
       env:
@@ -59,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +110,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -55,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: csharp
     prefix: psm-examples
-  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: csharp
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: csharp
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: csharp
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: csharp
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: csharp
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: csharp
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/csharp_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: csharp
     prefix: psm-examples
-  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-csharp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: csharp
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "csharp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: cxx
     prefix: psm-examples
-  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: cxx
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: cxx
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: cxx
     prefix: psm-examples
-  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: cxx
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    pool: ${workers_pool}
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    uniquifier: prebuilt-proxied
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: go
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,10 +42,22 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: go
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: go
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: go
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    pool: ${workers_pool}
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    uniquifier: prebuilt-proxyless
   labels:
     language: go
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: go
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,7 +48,12 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: go
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: java
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -107,7 +107,7 @@ spec:
             }
           ]
         },
-        "warmup_seconds": 5,
+        "warmup_seconds": 15,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,27 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: java
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: java
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +41,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +112,18 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: java
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: java
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: java
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +47,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +108,18 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: java
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: java
     prefix: psm-examples
-  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-java-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: java
@@ -56,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -103,7 +103,7 @@ spec:
             }
           ]
         },
-        "warmup_seconds": 5,
+        "warmup_seconds": 15,
         "benchmark_seconds": 30
       }
     }

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: node
     prefix: psm-examples
-  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: node
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: node
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: node
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: node
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: node
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: node
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: node
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: node
     prefix: psm-examples
-  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-node-to-node-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: node
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: php7
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: php7
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,27 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: php7
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: php7
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +41,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +112,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: php7
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: php7
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_worker.sh
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +47,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +108,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: php7
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-php7-protobuf-php-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: php7
@@ -56,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,27 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: php7_protobuf_c
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +41,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +112,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: php7_protobuf_c
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,30 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: php7_protobuf_c
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +47,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +108,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: cxx
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: php7_protobuf_c
     prefix: psm-examples
-  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-php7-protobuf-c-extension-to-cpp-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: php7_protobuf_c
@@ -56,7 +56,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python_asyncio
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python_asyncio
     name: '0'
+    pool: ${workers_pool}
     run:
-    - args:
+    - command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+      rgs:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
-      command:
-      - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
-      name: main
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: python_asyncio
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python_asyncio
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python_asyncio
     name: '0'
+    pool: ${workers_pool}
     run:
-    - args:
+    - command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+      rgs:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
-      command:
-      - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
-      name: main
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: python_asyncio
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: python
     prefix: psm-examples
-  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: python
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: python
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: python
     prefix: psm-examples
-  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: python
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: python
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -45,6 +35,9 @@ spec:
       - containers/runtime/xds-server/bootstrap.json
       command:
       - main
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
       image: ${psm_image_prefix}/xds-server:${psm_image_tag}
       livenessProbe:
         initialDelaySeconds: 30
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: python
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied
   labels:
     language: ruby
     prefix: psm-examples
-  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxied
 spec:
   clients:
   - language: ruby
@@ -61,7 +61,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,38 +5,28 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxied
   labels:
-    language: go
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxied
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: ruby
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -52,14 +42,26 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +113,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: ruby
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless
   labels:
     language: ruby
     prefix: psm-examples
-  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-prebuilt-proxyless
 spec:
   clients:
   - language: ruby
@@ -57,7 +57,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/ruby_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    pool: ${workers_pool}
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: prebuilt-proxyless
   labels:
-    language: go
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-prebuilt-proxyless
 spec:
   clients:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: ruby
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -55,11 +48,16 @@ spec:
   driver:
     language: cxx
     name: '0'
-    run: []
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -111,32 +109,19 @@ spec:
       }
     }
   servers:
-  - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
-      command:
-      - go
-    clone:
-      gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+  - language: ruby
     name: '0'
+    pool: ${workers_pool}
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -64,7 +64,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
@@ -5,38 +5,36 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +50,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +64,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +119,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
@@ -5,33 +5,34 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: python_asyncio
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-asyncio-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +115,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/python_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxied.yaml
@@ -5,38 +5,36 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: python
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +50,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +64,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +119,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/python_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: python
     prefix: psm-examples
-  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -64,7 +64,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
@@ -5,33 +5,34 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: python
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -114,29 +115,25 @@ spec:
   - build:
       args:
       - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
       command:
-      - go
+      - bazel
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc.git
+    language: python
     name: '0'
     run:
     - args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: python
     prefix: psm-examples
-  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-python-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -60,7 +60,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
@@ -5,38 +5,31 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
-    uniquifier: proxyless
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    uniquifier: proxied
   labels:
-    language: go
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       name: main
     - args:
       - -default-config-path
@@ -52,6 +45,13 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
   driver:
     language: cxx
     name: '0'
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +112,22 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400

--- a/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxied.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:
     language: ruby
     prefix: psm-examples
-  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxied
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxied
 spec:
   clients:
   - build:
@@ -59,7 +59,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:
     language: ruby
     prefix: psm-examples
-  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000load-proxyless
 spec:
   clients:
   - build:
@@ -55,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {

--- a/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/ruby_example_loadtest_proxyless.yaml
@@ -5,33 +5,29 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
+    scenario: ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load
     uniquifier: proxyless
   labels:
-    language: go
+    language: ruby
     prefix: psm-examples
-  name: psm-examples-go-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
+  name: psm-examples-ruby-protobuf-async-unary-5000rpcs-1kb-psm-8channels-16threads-5000offered-load-proxyless
 spec:
   clients:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
       env:
@@ -59,7 +55,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
+        "name": "ruby_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000offered_load",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -112,31 +108,22 @@ spec:
     }
   servers:
   - build:
-      args:
-      - build
-      - -o
-      - /src/workspace/bin/worker
-      - ./benchmark/worker
       command:
-      - go
+      - bash
+      - /build_scripts/build_qps_worker.sh
     clone:
       gitRef: master
-      repo: https://github.com/grpc/grpc-go.git
-    language: go
+      repo: https://github.com/grpc/grpc
+    language: ruby
     name: '0'
     run:
     - args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400


### PR DESCRIPTION
This commit contains the examples generated based on the templates added in https://github.com/grpc/grpc/pull/29447
in grpc/grpc.

The examples are generated by following command when run at the root of grpc/grpc once https://github.com/grpc/grpc/pull/29447 merged:
```
./tools/run_tests/performance/loadtest_examples.sh ../test-infra/config/samples
```