### PR TITLE
Collect logs from all containers and add log to test properties.

### DIFF
--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -78,7 +78,7 @@ func main() {
 	log.Printf("Queue concurrency levels: %v", c)
 	log.Printf("Output directories: %v", outputDirMap)
 	if logURLPrefix != "" {
-		log.Printf("Prefix for url for saved logs: %s", logURLPrefix)
+		log.Printf("Prefix for log urls: %s", logURLPrefix)
 	}
 
 	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests, runner.NewPodsGetter(), logURLPrefix)

--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -81,7 +81,7 @@ func main() {
 		log.Printf("Prefix for log urls: %s", logURLPrefix)
 	}
 
-	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests, runner.NewPodsGetter(), logURLPrefix)
+	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.NewPodsGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests, logURLPrefix)
 
 	logPrefixFmt := runner.LogPrefixFmt(configQueueMap)
 

--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -34,18 +34,18 @@ func main() {
 	var c runner.ConcurrencyLevels
 	var a string
 	var p time.Duration
-	var u string
 	var retries uint
 	var deleteSuccessfulTests bool
+	var logURLPrefix string
 
 	flag.Var(&i, "i", "input files containing load test configurations")
 	flag.StringVar(&o, "o", "", "name of the output file for xunit xml report")
 	flag.Var(&c, "c", "concurrency level, in the form [<queue name>:]<concurrency level>")
 	flag.StringVar(&a, "annotation-key", "pool", "annotation key to parse for queue assignment")
-	flag.StringVar(&u, "log-url-prefix", "", "prefix for log urls")
 	flag.DurationVar(&p, "polling-interval", 20*time.Second, "polling interval for load test status")
 	flag.UintVar(&retries, "polling-retries", 2, "Maximum retries in case of communication failure")
 	flag.BoolVar(&deleteSuccessfulTests, "delete-successful-tests", false, "Delete tests immediately in case of successful termination")
+	flag.StringVar(&logURLPrefix, "log-url-prefix", "", "prefix for log urls")
 	flag.Parse()
 
 	inputConfigs, err := runner.DecodeFromFiles(i)
@@ -71,11 +71,6 @@ func main() {
 		outputDirMap[qName] = outputDir
 	}
 
-	logURLPrefix := ""
-	if u != "" {
-		logURLPrefix = "http://cnsviewer2/placer/prod/home/kokoro-dedicated/build_artifacts/" + u + "/github/grpc/"
-	}
-
 	log.Printf("Annotation key for queue assignment: %s", a)
 	log.Printf("Polling interval: %v", p)
 	log.Printf("Polling retries: %d", retries)
@@ -86,7 +81,7 @@ func main() {
 		log.Printf("Prefix for url for saved logs: %s", logURLPrefix)
 	}
 
-	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests, runner.NewLogSaver(runner.NewPodsGetter(), logURLPrefix))
+	r := runner.NewRunner(runner.NewLoadTestGetter(), runner.AfterIntervalFunction(p), retries, deleteSuccessfulTests, runner.NewPodsGetter(), logURLPrefix)
 
 	logPrefixFmt := runner.LogPrefixFmt(configQueueMap)
 

--- a/tools/runner/client.go
+++ b/tools/runner/client.go
@@ -91,13 +91,14 @@ func NewPodsGetter() corev1types.PodsGetter {
 // GetTestPods retrieves the pods associated with a LoadTest.
 func GetTestPods(ctx context.Context, loadTest *grpcv1.LoadTest, podsGetter corev1types.PodsGetter) ([]*corev1.Pod, error) {
 	podLister := podsGetter.Pods(metav1.NamespaceAll)
-	// Get a list of all pods
+
+	// Get a list of all pods.
 	podList, err := podLister.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch list of pods: %v", err)
 	}
 
-	// Get pods just for this specific test
+	// Get pods just for this specific test.
 	testPods := status.PodsForLoadTest(loadTest, podList.Items)
 	return testPods, nil
 }

--- a/tools/runner/client.go
+++ b/tools/runner/client.go
@@ -18,7 +18,7 @@ package runner
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -94,7 +94,7 @@ func GetTestPods(ctx context.Context, loadTest *grpcv1.LoadTest, podsGetter core
 	// Get a list of all pods
 	podList, err := podLister.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.New("Failed to fetch list of pods")
+		return nil, fmt.Errorf("failed to fetch list of pods: %v", err)
 	}
 
 	// Get pods just for this specific test

--- a/tools/runner/logsaver.go
+++ b/tools/runner/logsaver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
+	"github.com/grpc/test-infra/config"
 	"github.com/grpc/test-infra/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +80,7 @@ func (ls *LogSaver) getTestPods(ctx context.Context, loadTest *grpcv1.LoadTest) 
 }
 
 func (ls *LogSaver) getPodLogBuffer(ctx context.Context, pod *corev1.Pod) (*bytes.Buffer, error) {
-	req := ls.podsGetter.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	req := ls.podsGetter.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: config.RunContainerName})
 	driverLogs, err := req.Stream(ctx)
 	if err != nil {
 		return nil, err

--- a/tools/runner/logsaver.go
+++ b/tools/runner/logsaver.go
@@ -1,112 +1,88 @@
+/*
+Copyright 2021 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package runner
 
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	grpcv1 "github.com/grpc/test-infra/api/v1"
-	"github.com/grpc/test-infra/status"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1types "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-// LogSaver provides functionality to save pod logs to files.
-type LogSaver struct {
-	podsGetter   corev1types.PodsGetter
-	logURLPrefix string
-}
-
-// NewLogSaver creates a new LogSaver object.
-func NewLogSaver(podsGetter corev1types.PodsGetter, logURLPrefix string) *LogSaver {
-	return &LogSaver{
-		podsGetter:   podsGetter,
-		logURLPrefix: logURLPrefix,
-	}
-}
-
-// SavePodLogs saves container logs to files with name in format
+// SaveLogs saves logs to files, the name of the files are in format
 // pod-name-container-name.log.
-// This function returns a map where pods are keys and values are the filepath
-// of the saved log.
-func (ls *LogSaver) SavePodLogs(ctx context.Context, loadTest *grpcv1.LoadTest, podLogDir string) (*SavedLogs, error) {
-	savedLogs := NewSavedLogs()
-
-	// Get pods for this test
-	pods, err := ls.getTestPods(ctx, loadTest)
-	if err != nil {
-		return savedLogs, err
-	}
+// This function returns a list of pointers of LogInfo.
+func SaveLogs(ctx context.Context, loadTest *grpcv1.LoadTest, pods []*corev1.Pod, podsGetter corev1types.PodsGetter, podLogDir string) ([]*LogInfo, error) {
+	logInfos := []*LogInfo{}
 
 	// Attempt to create directory. Will not error if directory already exists
-	err = os.MkdirAll(podLogDir, os.ModePerm)
+	err := os.MkdirAll(podLogDir, os.ModePerm)
 	if err != nil {
-		return savedLogs, fmt.Errorf("Failed to create pod log output directory %s: %v", podLogDir, err)
+		return logInfos, fmt.Errorf("Failed to create pod log output directory %s: %v", podLogDir, err)
 	}
 
 	// Write logs to files
 	for _, pod := range pods {
-		containerNametoLogPathMap := make(map[string]string)
-		containerNamesToLogMap, err := ls.getPodLogBuffers(ctx, pod)
-		if err != nil {
-			return savedLogs, fmt.Errorf("could not get log from pod: %s", err)
-		}
-		for containerName, buffer := range containerNamesToLogMap {
-			logFilePath := filepath.Join(podLogDir, fmt.Sprintf("%s-%s.log", pod.Name, containerName))
-			err = ls.writeBufferToFile(buffer, logFilePath)
+		for _, container := range pod.Spec.Containers {
+			logBuffer, err := GetLogBuffer(ctx, pod, podsGetter, container.Name)
+
 			if err != nil {
-				return savedLogs, fmt.Errorf("could not write %s container in %s pod log buffer to file: %s", containerName, pod.Name, err)
+				return logInfos, fmt.Errorf("could not get log from pod: %s", err)
 			}
-			containerNametoLogPathMap[containerName] = logFilePath
-		}
 
-		savedLogs.podToPathMap[pod] = containerNametoLogPathMap
+			if logBuffer.Len() == 0 {
+				continue
+			}
+
+			logFilePath := filepath.Join(podLogDir, fmt.Sprintf("%s-%s.log", pod.Name, container.Name))
+			logInfo := NewLogInfo(PodNameElement(pod.Name, loadTest.Name), container.Name, logFilePath)
+
+			err = writeBufferToFile(logBuffer, logFilePath)
+			if err != nil {
+				return logInfos, fmt.Errorf("could not write %s container in %s pod log buffer to file: %s", logInfo.containerName, pod.Name, err)
+			}
+
+			logInfos = append(logInfos, logInfo)
+		}
 	}
-	return savedLogs, nil
+	return logInfos, nil
 }
 
-// getTestPods retrieves the pods associated with a LoadTest.
-func (ls *LogSaver) getTestPods(ctx context.Context, loadTest *grpcv1.LoadTest) ([]*corev1.Pod, error) {
-	podLister := ls.podsGetter.Pods(metav1.NamespaceAll)
-
-	// Get a list of all pods
-	podList, err := podLister.List(ctx, metav1.ListOptions{})
+// GetLogBuffer retrieves logs from a specific container
+// in the given pod and return the log buffer.
+func GetLogBuffer(ctx context.Context, pod *corev1.Pod, podsGetter corev1types.PodsGetter, containerName string) (*bytes.Buffer, error) {
+	req := podsGetter.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: containerName})
+	containerLogs, err := req.Stream(ctx)
 	if err != nil {
-		return nil, errors.New("Failed to fetch list of pods")
+		return nil, err
 	}
-
-	// Get pods just for this specific test
-	testPods := status.PodsForLoadTest(loadTest, podList.Items)
-	return testPods, nil
+	defer containerLogs.Close()
+	logBuffer := new(bytes.Buffer)
+	logBuffer.ReadFrom(containerLogs)
+	return logBuffer, nil
 }
 
-// getPodLogBuffers retrieves logs from all existing containers
-// from the pod and save the log buffers in a map, the key of
-// the map is the container name and the value of the map is the
-// log buffers.
-func (ls *LogSaver) getPodLogBuffers(ctx context.Context, pod *corev1.Pod) (map[string]*bytes.Buffer, error) {
-	containerNamesToLogMap := make(map[string]*bytes.Buffer)
-	for _, container := range pod.Spec.Containers {
-		req := ls.podsGetter.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name})
-		containerLogs, err := req.Stream(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer containerLogs.Close()
-		logBuffer := new(bytes.Buffer)
-		logBuffer.ReadFrom(containerLogs)
-		containerNamesToLogMap[container.Name] = logBuffer
-	}
-	return containerNamesToLogMap, nil
-}
-
-func (ls *LogSaver) writeBufferToFile(buffer *bytes.Buffer, filePath string) error {
+func writeBufferToFile(buffer *bytes.Buffer, filePath string) error {
 	// Don't write empty buffers
 	if buffer.Len() == 0 {
 		return nil
@@ -127,47 +103,4 @@ func (ls *LogSaver) writeBufferToFile(buffer *bytes.Buffer, filePath string) err
 	}
 
 	return nil
-}
-
-// SavedLogs adds functions to get information about saved pod logs.
-type SavedLogs struct {
-	podToPathMap map[*corev1.Pod]map[string]string
-}
-
-// NewSavedLogs creates a new SavedLogs object.
-func NewSavedLogs() *SavedLogs {
-	return &SavedLogs{
-		podToPathMap: make(map[*corev1.Pod]map[string]string),
-	}
-}
-
-// GenerateNameProperties creates pod-name related properties.
-func (sl *SavedLogs) GenerateNameProperties(loadTest *grpcv1.LoadTest) map[string]string {
-	properties := make(map[string]string)
-	for pod := range sl.podToPathMap {
-		name := sl.podToPropertyName(pod.Name, loadTest.Name, "name")
-		properties[name] = pod.Name
-	}
-	return properties
-}
-
-// GenerateLogProperties creates pod-log related properties.
-func (sl *SavedLogs) GenerateLogProperties(loadTest *grpcv1.LoadTest, logURLPrefix string) map[string]string {
-	properties := make(map[string]string)
-	for pod, buffers := range sl.podToPathMap {
-		for containerName, logFilePath := range buffers {
-			elementName := "log." + containerName
-			name := sl.podToPropertyName(pod.Name, loadTest.Name, elementName)
-			url := logURLPrefix + logFilePath
-			properties[name] = url
-		}
-	}
-	return properties
-}
-
-func (sl *SavedLogs) podToPropertyName(podName, loadTestName, elementName string) string {
-	prefix := fmt.Sprintf("%s-", loadTestName)
-	podNameSuffix := strings.TrimPrefix(podName, prefix)
-	propertyName := fmt.Sprintf("pod.%s.%s", podNameSuffix, elementName)
-	return propertyName
 }

--- a/tools/runner/properties.go
+++ b/tools/runner/properties.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// LogInfo contains infomation for a log entry.
+type LogInfo struct {
+	podNameElement string
+	containerName  string
+	logPath        string
+}
+
+// NewLogInfo creates a pointer of new LogInfo object.
+func NewLogInfo(podNameElement string, containerName string, logPath string) *LogInfo {
+	return &LogInfo{
+		podNameElement: podNameElement,
+		containerName:  containerName,
+		logPath:        logPath,
+	}
+}
+
+// PodLogProperties creates container log property name to
+// container log link map.
+func PodLogProperties(logInfos []*LogInfo, logURLPrefix string) map[string]string {
+	properties := make(map[string]string)
+	for _, logInfo := range logInfos {
+		prefix := []string{logInfo.podNameElement, "name", "log", logInfo.containerName}
+		podLogPropertyKey := strings.Join(prefix, ".")
+		url := logURLPrefix + logInfo.logPath
+		properties[podLogPropertyKey] = url
+	}
+	return properties
+}
+
+// PodNameElement trim off the loadtest name from the pod name,
+// and return only the element of pod name such as client-0,
+// driver-0 and server-0.
+func PodNameElement(podName, loadTestName string) string {
+	prefix := fmt.Sprintf("%s-", loadTestName)
+	podNameElement := strings.TrimPrefix(podName, prefix)
+	return podNameElement
+}
+
+// PodNameProperties creates pod property name to pod name map.
+func PodNameProperties(pods []*corev1.Pod, loadTestName string) map[string]string {
+	properties := make(map[string]string)
+	for _, pod := range pods {
+		prefix := []string{PodNameElement(pod.Name, loadTestName), "name"}
+		podNamePropertyKey := strings.Join(prefix, ".")
+		properties[podNamePropertyKey] = pod.Name
+	}
+
+	return properties
+}

--- a/tools/runner/properties.go
+++ b/tools/runner/properties.go
@@ -25,18 +25,17 @@ import (
 
 // LogInfo contains infomation for each log file.
 type LogInfo struct {
-	// PodNameElem is a part of the pod name.
-	// PodNameElem is the remaining part of the pod name after the
-	// subtraction of the LoadTest name. Examples of the PodNameElem
-	// are: client-0, driver-0 and server-0.
+	// PodNameElem is the element added to the LoadTest name to
+	// construct the pod name. Examples of PodNameElem are client-0,
+	// driver-0 and server-0.
 	PodNameElem string
 	// ContainerName is the container's name where the log comes from.
 	ContainerName string
-	// LogPath is where the log is saved.
+	// LogPath is the path pointing to the log file.
 	LogPath string
 }
 
-// PodLogProperties creates log property name to property value map.
+// PodLogProperties creates a map of log property keys to log path urls.
 func PodLogProperties(logInfos []*LogInfo, logURLPrefix string, prefix ...string) map[string]string {
 	properties := make(map[string]string)
 	for _, logInfo := range logInfos {
@@ -47,24 +46,13 @@ func PodLogProperties(logInfos []*LogInfo, logURLPrefix string, prefix ...string
 	return properties
 }
 
-// PodNameElem generate the pod name element.
-//
-// PodNameElem trims off the given LoadTest name and "-" from the
-// given pod name,returns remaining part such as client-0,
-// driver-0 and server-0.
-func PodNameElem(podName, loadTestName string) string {
-	prefix := fmt.Sprintf("%s-", loadTestName)
-	podNameElement := strings.TrimPrefix(podName, prefix)
-	return podNameElement
-}
-
 // PodLogPropertyKey generates the key for a pod log property.
 func PodLogPropertyKey(logInfo *LogInfo, prefix ...string) string {
 	key := strings.Join(append(prefix, logInfo.PodNameElem, "log", logInfo.ContainerName), ".")
 	return key
 }
 
-// PodNameProperties creates pod property name to pod name map.
+// PodNameProperties creates a map of pod name property keys to pod names.
 func PodNameProperties(pods []*corev1.Pod, loadTestName string, prefix ...string) map[string]string {
 	properties := make(map[string]string)
 	for _, pod := range pods {
@@ -73,6 +61,15 @@ func PodNameProperties(pods []*corev1.Pod, loadTestName string, prefix ...string
 	}
 
 	return properties
+}
+
+// PodNameElem returns the pod name element used to construct a pod name.
+// Pods within a LoadTest are distinguished by elements attached to the
+// LoadTest name, such as client-0, driver-0, server-0.
+func PodNameElem(podName, loadTestName string) string {
+	prefix := fmt.Sprintf("%s-", loadTestName)
+	podNameElem := strings.TrimPrefix(podName, prefix)
+	return podNameElem
 }
 
 // PodNamePropertyKey generates the key for a pod name property.

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -148,11 +148,11 @@ func (r *Runner) runTest(ctx context.Context, config *grpcv1.LoadTest, reporter 
 		case loadTest.Status.State.IsTerminated():
 			pods, err := GetTestPods(ctx, loadTest, r.PodsGetter)
 			if err != nil {
-				reporter.Error("Could not list all pods belongs to %s: %s", loadTest.Name, err)
+				reporter.Error("Could not list all pods: %v", err)
 			}
 			savedLogInfos, err := SaveAllLogs(ctx, loadTest, r.PodsGetter, pods, outputDir)
 			if err != nil {
-				reporter.Error("Could not save pod logs: %s", err)
+				reporter.Error("Could not save pod logs: %v", err)
 			}
 			reporter.AddProperty("name", loadTest.Name)
 			for property, value := range PodNameProperties(pods, loadTest.Name, "pod") {

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -146,9 +146,16 @@ func (r *Runner) runTest(ctx context.Context, config *grpcv1.LoadTest, reporter 
 				reporter.Error("Could not save pod logs: %s", err)
 			}
 			reporter.AddProperty("name", loadTest.Name)
-			for property, value := range savedLogs.GenerateProperties(loadTest) {
+			for property, value := range savedLogs.GenerateNameProperties(loadTest) {
 				reporter.AddProperty(property, value)
 			}
+
+			if r.logSaver.logURLPrefix != "" {
+				for property, value := range savedLogs.GenerateLogProperties(loadTest, r.logSaver.logURLPrefix) {
+					reporter.AddProperty(property, value)
+				}
+			}
+
 			if status != "Succeeded" {
 				reporter.Error("Test failed with reason %q: %v", loadTest.Status.Reason, loadTest.Status.Message)
 			} else {


### PR DESCRIPTION
This PR updated the infrastructure to save logs to file from all existing container which produces logs.  We have also separate the property generation of name property and log properties to avoid dependencies.

We also add the log link to the Xunit reports when there are pod logs.