### PR TITLE
Fix typo for the position of ENV for python prebuilt worker.

### DIFF
--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -26,6 +26,9 @@ spec:
             --driver_port="${DRIVER_PORT}"
       command:
       - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
       image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
@@ -35,9 +38,6 @@ spec:
       - containers/runtime/xds-server/bootstrap.json
       command:
       - main
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       image: ${psm_image_prefix}/xds-server:${psm_image_tag}
       livenessProbe:
         initialDelaySeconds: 30


### PR DESCRIPTION
The `GRPC_XDS_BOOTSTRAP` was accidentally attached to xds-server container in the psm python loadtest template with prebuilt workers. This commit is to put the `GRPC_XDS_BOOTSTRAP` ENV back to the main container where it is required.

Should be merged together with https://github.com/grpc/grpc/pull/29473