### PR TITLE
Add uniquifier to test case name.

### DIFF
--- a/tools/cmd/runner/main.go
+++ b/tools/cmd/runner/main.go
@@ -96,7 +96,7 @@ func main() {
 	done := make(chan *runner.TestSuiteReporter)
 
 	for qName, configs := range configQueueMap {
-		testSuiteReporter := reporter.NewTestSuiteReporter(qName, logPrefixFmt, runner.TestCaseNameFromAnnotations("scenario"))
+		testSuiteReporter := reporter.NewTestSuiteReporter(qName, logPrefixFmt, runner.TestCaseNameFromAnnotations("scenario", "uniquifier"))
 		testSuiteReporter.SetStartTime(time.Now())
 		go r.Run(ctx, configs, testSuiteReporter, c[qName], outputDirMap[qName], done)
 	}


### PR DESCRIPTION
This commit add uniquifier field from annotation to the test case names.
This is needed since the PSM tests are running the same scenario with 
proxied and proxyless setups, using only scenario name for the test case
can not differentiate proxied and proxyless tests.