### PR TITLE
Fix Docker file for java benchmarks.

### DIFF
--- a/containers/pre_built_workers/java/Dockerfile
+++ b/containers/pre_built_workers/java/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gradle:jdk11
+FROM openjdk:11-jdk-bullseye
 
 RUN mkdir -p /pre
 WORKDIR /pre
@@ -35,9 +35,9 @@ RUN git submodule update --init
 RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
 RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 
-RUN gradle -PskipAndroid=true -PskipCodegen=true :grpc-benchmarks:installDist
+RUN ./gradlew -PskipAndroid=true -PskipCodegen=true -Dorg.gradle.jvmargs=-Xmx2g :grpc-benchmarks:installDist
 
-FROM openjdk:11
+FROM openjdk:11-jdk-slim-bullseye
 
 RUN mkdir -p /execute
 WORKDIR /execute


### PR DESCRIPTION
Increased JVM memory limit to 2g for gradle build.

Increased memory requirement was introduced by https://github.com/grpc/grpc-java/pull/9101.

Build now passes:

```shell
 docker build --no-cache --build-arg="$GITREF" containers/pre_built_workers/java/
```

Build argument can be omitted to build from `master`.

