### PR TITLE
Update support for csharp core implementation.

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -14,6 +14,11 @@ The examples in this folder are basic examples that build and run the test
 components when the test is applied, and do not save data to BigQuery. These can
 be run by applying them to the cluster with `kubectl apply -f`.
 
+Special considerations is required for running csharp examples, the support of
+csharp in [grc/grpc](https://github.com/grpc/grpc) is removed by
+<https://github.com/grpc/grpc/pull/29225>, csharp benchmark test is only
+supported by version v1.45.2 and earlier versions.
+
 The examples in the [templates](./templates) folder are templates that use
 prebuilt images and require parameter substitution before running.
 [Tools](../../tools/README.md) are provided to build images and run tests with

--- a/containers/init/build/csharp/build_qps_worker.sh
+++ b/containers/init/build/csharp/build_qps_worker.sh
@@ -15,6 +15,13 @@
 
 set -ex
 
+# Check if the grpc version is compatible with the test
+FILE=tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+if [ ! -f "$FILE" ]; then
+    echo "Current gRPC version does not support csharp(core) benchmark test, please use a compatible gRPC version, see details in https://github.com/grpc/grpc/pull/29225."
+    exit 1
+fi
+
 # Build C# native extension with cmake
 mkdir -p cmake/build
 pushd cmake/build

--- a/containers/pre_built_workers/csharp/build_qps_worker.sh
+++ b/containers/pre_built_workers/csharp/build_qps_worker.sh
@@ -15,6 +15,13 @@
 
 set -ex
 
+# Check if the grpc version is compatible with the test
+FILE=tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+if [ ! -f "$FILE" ]; then
+    echo "Current gRPC version does not support csharp(core) benchmark test, please use a compatible gRPC version, see details in https://github.com/grpc/grpc/pull/29225."
+    exit 1
+fi
+
 # Build C# native extension with cmake
 mkdir -p cmake/build
 pushd cmake/build


### PR DESCRIPTION
This commit adds the proper error message in the Dockerfiles
when user trying to build the csharp benchmark worker with 
an incompatible grpc/grpc version.

This commit also add explanation for csharp example  in 
README.md in the config/sample folder.
