### PR TITLE
Make collection of Prometheus data be controlled by an annotation.

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -66,6 +66,10 @@ const (
 	// DriverPortEnv specifies the name of the env variable that contains driver port.
 	DriverPortEnv = "DRIVER_PORT"
 
+	// EnablePrometheusEnv specifies the name of the env variable that indicates if the
+	// Prometheus data is collected.
+	EnablePrometheusEnv = "ENABLE_PROMETHEUS"
+
 	// PoolLabel is the key for a label which will have the name of a pool as
 	// the value.
 	PoolLabel = "pool"

--- a/config/constants.go
+++ b/config/constants.go
@@ -66,9 +66,9 @@ const (
 	// DriverPortEnv specifies the name of the env variable that contains driver port.
 	DriverPortEnv = "DRIVER_PORT"
 
-	// DisablePrometheusEnv specifies the name of the env variable that indicates
-	// if the collection of Prometheus data is disabled.
-	DisablePrometheusEnv = "DISABLE_PROMETHEUS"
+	// EnablePrometheusEnv specifies the name of the env variable that indicates
+	// if the collection of Prometheus data is enabled.
+	EnablePrometheusEnv = "ENABLE_PROMETHEUS"
 
 	// PoolLabel is the key for a label which will have the name of a pool as
 	// the value.

--- a/config/constants.go
+++ b/config/constants.go
@@ -66,9 +66,9 @@ const (
 	// DriverPortEnv specifies the name of the env variable that contains driver port.
 	DriverPortEnv = "DRIVER_PORT"
 
-	// EnablePrometheusEnv specifies the name of the env variable that indicates if the
-	// Prometheus data is collected.
-	EnablePrometheusEnv = "ENABLE_PROMETHEUS"
+	// DisablePrometheusEnv specifies the name of the env variable that indicates
+	// if the collection of Prometheus data is disabled.
+	DisablePrometheusEnv = "DISABLE_PROMETHEUS"
 
 	// PoolLabel is the key for a label which will have the name of a pool as
 	// the value.

--- a/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/cxx_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/go_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/go_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/java_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/java_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/node_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/node_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/php7_protobuf_c_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/cxx_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/go_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: go_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/java_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: java_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/node_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: node_to_node_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/php7_protobuf_c_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_asyncio_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxied_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxied

--- a/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
+++ b/config/samples/templates/psm/prebuilt/python_example_loadtest_proxyless_with_prebuilt_workers.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     pool: ${workers_pool}
     scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: prebuilt-proxyless

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_asyncio_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/config/samples/templates/psm/python_example_loadtest_proxied.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxied.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxied
   labels:

--- a/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
+++ b/config/samples/templates/psm/python_example_loadtest_proxyless.yaml
@@ -5,6 +5,7 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
+    enablePrometheus: 'true'
     scenario: python_protobuf_async_unary_5000rpcs_1KB_psm_8channels_16threads_5000load
     uniquifier: proxyless
   labels:

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y \
   pkg-config \
   gnupg \
   apt-transport-https \
+  dnsutils \
   ca-certificates
 
 RUN apt-get update && apt-get install -y \

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -35,7 +35,7 @@ if [ -n "${BQ_RESULT_TABLE}" ]; then
   fi
   if [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
     cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
-    if [ -n "${SERVER_TARGET_OVERRIDE}" ]; then
+    if [ -n "${SERVER_TARGET_OVERRIDE}" ] || [ -n "${ENABLE_PROMETHEUS}" ]; then
       python3 /src/code/tools/run_tests/performance/prometheus.py \
         --url=http://prometheus.test-infra-system.svc.cluster.local:9090 \
         --pod_type=clients --container_name=main \

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -35,11 +35,13 @@ if [ -n "${BQ_RESULT_TABLE}" ]; then
   fi
   if [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
     cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
-    if  [ "$(dig +short -t srv prometheus.test-infra-system.svc.cluster.local)" ] && [ -z "${DISABLE_PROMETHEUS}" ]; then
-      python3 /src/code/tools/run_tests/performance/prometheus.py \
-        --url=http://prometheus.test-infra-system.svc.cluster.local:9090 \
-        --pod_type=clients --container_name=main \
-        --container_name=sidecar
+    if [ -z "${SERVER_TARGET_OVERRIDE}" ] || [ -z "${ENABLE_PROMETHEUS}" ]; then
+      if  [ "$(dig +short -t srv prometheus.test-infra-system.svc.cluster.local)" ]; then
+        python3 /src/code/tools/run_tests/performance/prometheus.py \
+          --url=http://prometheus.test-infra-system.svc.cluster.local:9090 \
+          --pod_type=clients --container_name=main \
+          --container_name=sidecar
+      fi
     fi
   fi
   python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table="${BQ_RESULT_TABLE}"

--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -35,7 +35,7 @@ if [ -n "${BQ_RESULT_TABLE}" ]; then
   fi
   if [ -r "${NODE_INFO_OUTPUT_FILE}" ]; then
     cp "${NODE_INFO_OUTPUT_FILE}" node_info.json
-    if [ -n "${SERVER_TARGET_OVERRIDE}" ] || [ -n "${ENABLE_PROMETHEUS}" ]; then
+    if  [ "$(dig +short -t srv prometheus.test-infra-system.svc.cluster.local)" ] && [ -z "${DISABLE_PROMETHEUS}" ]; then
       python3 /src/code/tools/run_tests/performance/prometheus.py \
         --url=http://prometheus.test-infra-system.svc.cluster.local:9090 \
         --pod_type=clients --container_name=main \

--- a/kubehelpers/psm.go
+++ b/kubehelpers/psm.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grpc/test-infra/config"
 )
 
-//IsPSMTest checks if a given LoadTest is a (proxied or proxyless) service
+// IsPSMTest checks if a given LoadTest is a (proxied or proxyless) service
 // mesh test. This test must be performed after validating the client specs.
 func IsPSMTest(clients *[]grpcv1.Client) bool {
 	for _, c := range *clients {

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -18,6 +18,7 @@ package podbuilder
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -238,6 +239,14 @@ func (pb *PodBuilder) PodForDriver(driver *grpcv1.Driver) (*corev1.Pod, error) {
 				Value: *bigQueryTable,
 			})
 		}
+	}
+
+	usePrometheus, ok := pb.test.Annotations["enablePrometheus"]
+	if ok && strings.ToLower(usePrometheus) == "true" {
+		runContainer.Env = append(runContainer.Env,
+			corev1.EnvVar{
+				Name:  config.EnablePrometheusEnv,
+				Value: "true"})
 	}
 
 	return pod, nil

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -241,11 +241,11 @@ func (pb *PodBuilder) PodForDriver(driver *grpcv1.Driver) (*corev1.Pod, error) {
 		}
 	}
 
-	usePrometheus, ok := pb.test.Annotations["enablePrometheus"]
-	if ok && strings.ToLower(usePrometheus) == "true" {
+	disablePrometheus, ok := pb.test.Annotations["disablePrometheus"]
+	if ok && strings.ToLower(disablePrometheus) == "true" {
 		runContainer.Env = append(runContainer.Env,
 			corev1.EnvVar{
-				Name:  config.EnablePrometheusEnv,
+				Name:  config.DisablePrometheusEnv,
 				Value: "true"})
 	}
 

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -241,11 +241,11 @@ func (pb *PodBuilder) PodForDriver(driver *grpcv1.Driver) (*corev1.Pod, error) {
 		}
 	}
 
-	disablePrometheus, ok := pb.test.Annotations["disablePrometheus"]
-	if ok && strings.ToLower(disablePrometheus) == "true" {
+	enablePrometheus, ok := pb.test.Annotations["enablePrometheus"]
+	if ok && strings.ToLower(enablePrometheus) == "true" {
 		runContainer.Env = append(runContainer.Env,
 			corev1.EnvVar{
-				Name:  config.DisablePrometheusEnv,
+				Name:  config.EnablePrometheusEnv,
 				Value: "true"})
 	}
 

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/status/missing_pods_test.go
+++ b/status/missing_pods_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Currently we automatically collect Prometheus data for PSM
related tests, now some regular tests (same scenario as PSM
test) are also part of the PSM tests, we may want to collect
Prometheus data for those regular tests too. The current method
for checking if a test isPSM related is to check the existence of
xds-server and sidecar containers.

The default behavior is to not collect any Prometheus data. 
This PR adds an annotation `enablePrometheus` to 
elect to collect Prometheus data, once this annotation is
set to `true` in a LoadTest configuration, the 
Prometheus data would be collected for that particular test. 