### PR TITLE
Enable driver to be able to use image supplied from load test configuration.

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -188,7 +188,10 @@ func (d *Defaults) setDriverDefaults(im *imageMap, testSpec *grpcv1.LoadTestSpec
 	if len(driver.Run) == 0 {
 		driver.Run = []corev1.Container{{Name: RunContainerName}}
 	}
-	driver.Run[0].Image = d.DriverImage
+
+	if driver.Run[0].Image == "" {
+		driver.Run[0].Image = d.DriverImage
+	}
 
 	driver.Name = unwrapStrOrUUID(driver.Name)
 	d.setCloneOrDefault(driver.Clone)

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -266,6 +266,15 @@ var _ = Describe("Defaults", func() {
 				Expect(driver.Run[0].Name).To(Equal(loadtest.Spec.Driver.Run[0].Name))
 			})
 
+			It("doesn't override the run container image if set", func() {
+				err := defaults.SetLoadTestDefaults(loadtest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(driver.Run[0].Image).ToNot(BeEmpty())
+				Expect(driver.Run[0].Image).To(Equal(loadtest.Spec.Driver.Run[0].Image))
+				Expect(driver.Run[0].Image).ToNot(Equal(defaults.DriverImage))
+			})
+
 			It("does not error if run container image cannot be inferred but is set", func() {
 				image := "example-image"
 


### PR DESCRIPTION
This commit enables driver to use image supplied from configuration file.
Before, the driver image was always overrides by the default driver image.