### PR TITLE
Add 20s delay to query using flag.

### DIFF
--- a/containers/runtime/driver/run.sh
+++ b/containers/runtime/driver/run.sh
@@ -40,7 +40,7 @@ if [ -n "${BQ_RESULT_TABLE}" ]; then
         python3 /src/code/tools/run_tests/performance/prometheus.py \
           --url=http://prometheus.test-infra-system.svc.cluster.local:9090 \
           --pod_type=clients --container_name=main \
-          --container_name=sidecar
+          --container_name=sidecar --delay_seconds=20
       fi
     fi
   fi


### PR DESCRIPTION
This PR enable the driver script using the flag added in https://github.com/grpc/grpc/pull/31611 to delay the query for 20s.