### PR TITLE
Upgrade ruby dockerfiles to ruby 3.1

### DIFF
--- a/containers/pre_built_workers/ruby/Dockerfile
+++ b/containers/pre_built_workers/ruby/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:2.5
+FROM ruby:3.1
 
 # TODO: when running on kokoro, this build step will not be cached
 # since we'll always be on a fresh VM. Re-running this command each
@@ -47,7 +47,7 @@ ADD build_qps_worker.sh /build_scripts
 RUN bash /build_scripts/build_qps_worker.sh
 
 # Copy node modules to a new image
-FROM ruby:2.5
+FROM ruby:3.1
 
 RUN mkdir -p /execute
 WORKDIR /execute


### PR DESCRIPTION
The ruby version is https://github.com/grpc/test-infra/blob/master/containers/pre_built_workers/ruby/Dockerfile#L15 no longer supported, so bump them to 3.1.