### PR TITLE
Update base image to fix controller vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@
 TEST_INFRA_VERSION ?= latest
 
 # Version of gRPC core used for the gRPC driver
-# Pinned to include the following PR:
-# https://github.com/grpc/grpc/pull/31611
-DRIVER_VERSION ?= d44e1520a73e928cf6d57de16ca821614c3c642b
+DRIVER_VERSION ?= v1.53.1
 
 # Prefix for all images used as clone and ready containers, enabling use with
 # registries other than Docker Hub

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod 777 /workspace/config/defaults.yaml
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/controller cmd/controller/main.go
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/base-debian11
 WORKDIR /workspace
 COPY --from=builder /workspace .
 CMD ["/workspace/bin/controller"]

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod 777 /workspace/config/defaults.yaml
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/controller cmd/controller/main.go
 
-FROM debian:buster
+FROM gcr.io/distroless/static-debian11
 WORKDIR /workspace
 COPY --from=builder /workspace .
 CMD ["/workspace/bin/controller"]

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod 777 /workspace/config/defaults.yaml
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/controller cmd/controller/main.go
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/static-debian11
 WORKDIR /workspace
 COPY --from=builder /workspace .
 CMD ["/workspace/bin/controller"]

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM marketplace.gcr.io/google/debian11
 
 ARG REPOSITORY=grpc/grpc
 ARG GITREF=master
@@ -42,7 +42,7 @@ RUN mkdir -p /tmp/build_output
 WORKDIR /src/code
 RUN bazel --output_user_root=/tmp/build_output build --config opt //test/cpp/qps:qps_json_driver
 
-FROM debian:buster
+FROM marketplace.gcr.io/google/debian11
 
 RUN mkdir -p /src/driver
 RUN mkdir -p /src/code


### PR DESCRIPTION
Replace debian:buster with the static-debian11 distroless image so as to avoid the reported security vulnerability.