### PR TITLE
Add C++ experiments tables to the PG replicator

### DIFF
--- a/dashboard/config/postgres_replicator/default/config.yaml
+++ b/dashboard/config/postgres_replicator/default/config.yaml
@@ -16,3 +16,13 @@ transfer:
       dateField: metadata.created
     - name: ci_master_results_32core
       dateField: metadata.created
+  - name: e2e_benchmark_cxx_experiments
+    tables:
+    - name: results_32core_event_engine_listener
+      dateField: metadata.created
+    - name: results_8core_event_engine_listener
+      dateField: metadata.created
+    - name: results_32core_work_stealing
+      dateField: metadata.created
+    - name: results_8core_work_stealing
+      dateField: metadata.created


### PR DESCRIPTION
I think we'll need to modify the replicator & grafana dashboard config every time we add a C++ experiment. This is is pretty high-touch, we may want to reconsider alternatives.