### PR TITLE
Add C++ experiments to PSM's replicator config

### DIFF
--- a/dashboard/config/postgres_replicator/psm/config.yaml
+++ b/dashboard/config/postgres_replicator/psm/config.yaml
@@ -18,3 +18,13 @@ transfer:
       dateField: metadata.created
     - name: psm_experimental_results_8core
       dateField: metadata.created
+  - name: e2e_benchmark_cxx_experiments
+    tables:
+    - name: results_32core_event_engine_listener
+      dateField: metadata.created
+    - name: results_8core_event_engine_listener
+      dateField: metadata.created
+    - name: results_32core_work_stealing
+      dateField: metadata.created
+    - name: results_8core_work_stealing
+      dateField: metadata.created


### PR DESCRIPTION
Due to the way the replicator is deployed, only the PSM replicator config is used. If the default is ever used, the PSM tables will stop getting populated.

@wanlin31 it may be worthwhile to unify the configs into the default replicator config, or separate them into multiple replicator jobs that are all running in parallel on disjoint sets of tables.