### PR TITLE
Add new C++ experiment to the replicator: `event_engine_listener,work_stealing`

### DIFF
--- a/dashboard/config/postgres_replicator/psm/config.yaml
+++ b/dashboard/config/postgres_replicator/psm/config.yaml
@@ -28,3 +28,7 @@ transfer:
       dateField: metadata.created
     - name: results_8core_work_stealing
       dateField: metadata.created
+    - name: results_32core_event_engine_listener__work_stealing
+      dateField: metadata.created
+    - name: results_8core_event_engine_listener__work_stealing
+      dateField: metadata.created


### PR DESCRIPTION
These tables do not exist yet, they will be created after the first run of the new configuration: https://github.com/grpc/grpc/pull/33940

CC @ctiller