### PR TITLE
Update dotnet docker images to .NET8

### DIFF
--- a/containers/init/build/dotnet/Dockerfile
+++ b/containers/init/build/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-preview-bookworm-slim
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-preview-bookworm-slim
 
 RUN mkdir -p /pre
 WORKDIR /pre
@@ -40,7 +40,7 @@ RUN dotnet publish -c Release -o qps_worker perf/benchmarkapps/QpsWorker/
 
 # Note that the QpsWorker built by "dotnet publish" in the previous step needs to be runnable
 # with the runtime image below.
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim
 
 # Enable dynamic profile-guided optimization
 # https://gist.github.com/EgorBo/dc181796683da3d905a5295bfd3dd95b

--- a/containers/runtime/dotnet/Dockerfile
+++ b/containers/runtime/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace


### PR DESCRIPTION
React to https://github.com/grpc/grpc-dotnet/pull/2021. This should fix the dotnet docker image build.