### PR TITLE
Fix checkout for driver build.

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /src/code
 
 RUN git clone https://github.com/$REPOSITORY.git .
 RUN git submodule update --init
-RUN git checkout $GITREF
+RUN git checkout -f $GITREF
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md
 FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:0f909e43012a80faa92e07b7871268841ce56ebc@sha256:1118150d9d9479787165fff49f660a3dc633f1c57604305460172fc1916aa022


### PR DESCRIPTION
This is a workaround for an error when checking out gRPC v1.58.1 for the driver build.