### PR TITLE
Update base images used for tests to golang:1.20.

### DIFF
--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -27,7 +27,7 @@ languages:
   runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
-  buildImage: golang:1.17
+  buildImage: golang:1.20
   runImage: "{{ .RunImagePrefix }}go:{{ .Version }}"
 
 - language: java

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Defaults", func() {
 				},
 				{
 					Language:   "go",
-					BuildImage: "golang:1.17",
+					BuildImage: "golang:1.20",
 					RunImage:   "gcr.io/grpc-fake-project/test-infra/go",
 				},
 				{

--- a/containers/init/ready/Dockerfile
+++ b/containers/init/ready/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.20
 
 RUN mkdir -p /src/ready
 WORKDIR /src/ready

--- a/containers/pre_built_workers/go/Dockerfile
+++ b/containers/pre_built_workers/go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.20
 
 RUN mkdir -p /executable
 WORKDIR /executable

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/containers/runtime/go/Dockerfile
+++ b/containers/runtime/go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.20
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/runtime/xds-server/Dockerfile
+++ b/containers/runtime/xds-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.20
 
 RUN mkdir /bootstrap
 WORKDIR /src/workspace

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -137,7 +137,7 @@ func newDefaults() *config.Defaults {
 			},
 			{
 				Language:   "go",
-				BuildImage: "golang:1.17",
+				BuildImage: "golang:1.20",
 				RunImage:   "gcr.io/grpc-fake-project/test-infra/go",
 			},
 			{

--- a/dashboard/config/postgres_replicator/Dockerfile
+++ b/dashboard/config/postgres_replicator/Dockerfile
@@ -15,7 +15,7 @@
 # syntax=docker/dockerfile:1
 
 # Build replicator
-FROM golang:1.17 AS builder
+FROM golang:1.20 AS builder
 
 ARG REPOSITORY=grpc/test-infra
 ARG GITREF=master
@@ -25,7 +25,7 @@ RUN git clone https://github.com/$REPOSITORY.git src \
     && make replicator REPLICATOR_OUTPUT_DIR=/
 
 # Copy replicator binary and run it
-FROM golang:1.17
+FROM golang:1.20
 WORKDIR /app
 COPY --from=builder /replicator /app
 COPY config.yaml /app

--- a/podbuilder/suite_test.go
+++ b/podbuilder/suite_test.go
@@ -96,7 +96,7 @@ func newDefaults() *config.Defaults {
 			},
 			{
 				Language:   "go",
-				BuildImage: "golang:1.17",
+				BuildImage: "golang:1.20",
 				RunImage:   "gcr.io/grpc-fake-project/test-infra/go",
 			},
 			{


### PR DESCRIPTION
grpc-go requires go1.19. Infrastructure will be updated separately.