### PR TITLE
Update dotnet docker images to .NET8 final

### DIFF
--- a/containers/init/build/dotnet/Dockerfile
+++ b/containers/init/build/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-preview-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-preview-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
 
 RUN mkdir -p /pre
 WORKDIR /pre
@@ -40,7 +40,7 @@ RUN dotnet publish -c Release -o qps_worker perf/benchmarkapps/QpsWorker/
 
 # Note that the QpsWorker built by "dotnet publish" in the previous step needs to be runnable
 # with the runtime image below.
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 # Enable dynamic profile-guided optimization
 # https://gist.github.com/EgorBo/dc181796683da3d905a5295bfd3dd95b

--- a/containers/runtime/dotnet/Dockerfile
+++ b/containers/runtime/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace


### PR DESCRIPTION
grpc-dotnet repo has moved to .NET 8 final SDK. This fixes failure related to SDK not being available in the docker image.

See https://github.com/grpc/grpc/pull/35069