### PR TITLE
Use driver from gRPC core 1.60.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TEST_INFRA_VERSION ?= latest
 
 # Version of gRPC core used for the gRPC driver
-DRIVER_VERSION ?= v1.58.1
+DRIVER_VERSION ?= v1.60.0
 
 # Prefix for all images used as clone and ready containers, enabling use with
 # registries other than Docker Hub

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TEST_INFRA_VERSION ?= latest
 
 # Version of gRPC core used for the gRPC driver
-DRIVER_VERSION ?= v1.60.0
+DRIVER_VERSION ?= v1.62.1
 
 # Prefix for all images used as clone and ready containers, enabling use with
 # registries other than Docker Hub

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/$REPOSITORY.git .
 RUN git checkout -f $GITREF
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md
-FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:0f909e43012a80faa92e07b7871268841ce56ebc@sha256:1118150d9d9479787165fff49f660a3dc633f1c57604305460172fc1916aa022
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:cacad91746cd598d8756de89b912be291de1f019@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf
 
 COPY --from=0 /src/code /src/code
 RUN mkdir -p /tmp/build_output


### PR DESCRIPTION
This is in preparation for using a driver that contains the fix grpc/grpc#35384.

There are no releases yet that contain the fix, but at least we can start by getting the latest and fixing the related problems.

There is in fact a pre-release with the fixed driver: [v1.61.0-pre1](https://github.com/grpc/grpc/releases/tag/v1.61.0-pre1).

Once this fix is merged, the fixed driver can be built by setting `DRIVER_VERSION` to `v1.61.0-pre1` or `master`.