### PR TITLE
No submodules for driver: not needed by bazel

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -31,7 +31,6 @@ RUN mkdir -p /src/code
 WORKDIR /src/code
 
 RUN git clone https://github.com/$REPOSITORY.git .
-RUN git submodule update --init
 RUN git checkout -f $GITREF
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md


### PR DESCRIPTION
This makes the build faster.

A similar fix is found in #145.
