### PR TITLE
Make it possible to configure a metrics port in pods

### DIFF
--- a/api/v1/loadtest_types.go
+++ b/api/v1/loadtest_types.go
@@ -181,6 +181,8 @@ type Server struct {
 	// Run describes a list of run containers. The container for the test server is always
 	// the first container on the list.
 	Run []corev1.Container `json:"run"`
+
+	MetricsPort int32 `json:"metricsPort,omitempty"`
 }
 
 // Client defines a component that sends traffic to a server component.
@@ -235,6 +237,8 @@ type Client struct {
 	// Run describes a list of run containers. The container for the test client is always
 	// the first container on the list.
 	Run []corev1.Container `json:"run"`
+
+	MetricsPort int32 `json:"metricsPort,omitempty"`
 }
 
 // Results defines where and how test results and artifacts should be

--- a/config/crd/bases/e2etest.grpc.io_loadtests.yaml
+++ b/config/crd/bases/e2etest.grpc.io_loadtests.yaml
@@ -232,6 +232,9 @@ spec:
                         image. If the user intends for the operator to clone and build
                         code, it must also manually set a build image."
                       type: string
+                    metricsPort:
+                      format: int32
+                      type: integer
                     name:
                       description: "Name is a string that distinguishes this client
                         from others in the test. Explicitly setting a name is recommended
@@ -2896,6 +2899,9 @@ spec:
                         image. If the user intends for the operator to clone and build
                         code, it must also manually set a build image."
                       type: string
+                    metricsPort:
+                      format: int32
+                      type: integer
                     name:
                       description: Name is a string that distinguishes this server
                         from others in the test. Since tests are currently limited

--- a/podbuilder/podbuilder.go
+++ b/podbuilder/podbuilder.go
@@ -177,6 +177,14 @@ func (pb *PodBuilder) PodForClient(client *grpcv1.Client) (*corev1.Pod, error) {
 		ContainerPort: config.DriverPort,
 	})
 
+	if client.MetricsPort != 0 {
+		runContainer.Ports = append(runContainer.Ports, corev1.ContainerPort{
+			Name:          "metrics",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: client.MetricsPort,
+		})
+	}
+
 	return pod, nil
 }
 
@@ -284,6 +292,14 @@ func (pb *PodBuilder) PodForServer(server *grpcv1.Server) (*corev1.Pod, error) {
 		Protocol:      corev1.ProtocolTCP,
 		ContainerPort: config.DriverPort,
 	})
+
+	if server.MetricsPort != 0 {
+		runContainer.Ports = append(runContainer.Ports, corev1.ContainerPort{
+			Name:          "metrics",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: server.MetricsPort,
+		})
+	}
 
 	return pod, nil
 }

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -388,7 +388,7 @@ var _ = Describe("PodBuilder", func() {
 				Expect(getNames(runContainer.Ports)).NotTo(ContainElement("metrics"))
 			})
 
-			It("does not expose the metrics port if not set", func() {
+			It("exposes the metrics port if set", func() {
 				client.Run = []corev1.Container{{}}
 				client.Run[0].Name = config.RunContainerName
 				client.Run[0].Command = []string{"go"}

--- a/podbuilder/podbuilder_test.go
+++ b/podbuilder/podbuilder_test.go
@@ -374,6 +374,36 @@ var _ = Describe("PodBuilder", func() {
 				Expect(getValue("driver", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(config.DriverPort))
 			})
 
+			It("does not expose the metrics port if not set", func() {
+				client.Run = []corev1.Container{{}}
+				client.Run[0].Name = config.RunContainerName
+				client.Run[0].Command = []string{"go"}
+				client.Run[0].Args = []string{"run", "main.go"}
+
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers).ToNot(BeEmpty())
+
+				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+				Expect(getNames(runContainer.Ports)).NotTo(ContainElement("metrics"))
+			})
+
+			It("does not expose the metrics port if not set", func() {
+				client.Run = []corev1.Container{{}}
+				client.Run[0].Name = config.RunContainerName
+				client.Run[0].Command = []string{"go"}
+				client.Run[0].Args = []string{"run", "main.go"}
+				client.MetricsPort = 4242
+
+				pod, err := builder.PodForClient(client)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers).ToNot(BeEmpty())
+
+				runContainer := kubehelpers.ContainerForName(config.RunContainerName, pod.Spec.Containers)
+				Expect(getNames(runContainer.Ports)).To(ContainElement("metrics"))
+				Expect(getValue("metrics", "ContainerPort", runContainer.Ports)).To(BeEquivalentTo(client.MetricsPort))
+			})
+
 			It("attached the env to other run containers", func() {
 				pod, err := builder.PodForClient(client)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR currently includes changes from https://github.com/grpc/test-infra/pull/390

We (Spotify) are currently using this framework to set up automated benchmarking for our internal gRPC. While we have metrics from the driver for performance comparison, we would like to scrape and see actual metrics from the client/server in many cases. This PR adds a configuration `metricsPort` for both client and server. A metrics port with configured port number is exposed in the pod if configured, otherwise no extra ports are exposed.