### PR TITLE
Fix build issues

### DIFF
--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -75,9 +75,9 @@ RUN apt-get update && apt-get install -y \
   python3-setuptools \
   python3-yaml
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
-  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | tee /usr/share/keyrings/cloud.google.gpg > /dev/null 2>&1
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN apt-get update -y && apt-get install google-cloud-sdk -y
 
 RUN apt-get clean
 

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -75,9 +75,11 @@ RUN apt-get update && apt-get install -y \
   python3-setuptools \
   python3-yaml
 
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | tee /usr/share/keyrings/cloud.google.gpg > /dev/null 2>&1
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN apt-get update -y && apt-get install google-cloud-sdk -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+  gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+  apt-get update -y && apt-get install google-cloud-cli -y
 
 RUN apt-get clean
 


### PR DESCRIPTION
Same fix as https://github.com/GoogleCloudPlatform/gke-managed-certs/commit/fa3e1a4b5f12502f4396e8810ccf2370eae42348

Installation of gcloud SDK fails when building driver image:

```
 => ERROR [stage-2 11/15] RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" |   tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && c  12.2s
------
 > [stage-2 11/15] RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" |   tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg |   apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y:
#26 0.243 deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main
#26 0.306   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#26 0.306                                  Dload  Upload   Total   Spent    Left  Speed
100  2659  100  2659    0     0   5318      0 --:--:-- --:--:-- --:--:--  5404
#26 0.835 Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
#26 1.069 OK
#26 1.559 Hit:1 http://deb.debian.org/debian bullseye InRelease
#26 1.559 Hit:2 http://deb.debian.org/debian-security bullseye-security InRelease
#26 1.575 Hit:3 http://deb.debian.org/debian bullseye-updates InRelease
#26 1.930 Get:4 http://packages.cloud.google.com/apt cloud-sdk InRelease [1616 B]
#26 6.520 Err:5 http://packages.cloud.google.com/apt cloud-sdk/main amd64 Packages
#26 6.520   502  Bad Gateway [IP: 142.250.74.110 80]
#26 6.696 Err:6 http://packages.cloud.google.com/apt cloud-sdk/main all Packages
#26 6.696
#26 6.778 Fetched 1616 B in 5s (301 B/s)
#26 6.778 Reading package lists...
#26 9.053 W: Failed to fetch http://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages  502  Bad Gateway [IP: 142.250.74.110 80]
#26 9.054 W: Failed to fetch http://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-all/Packages
#26 9.054 W: Some index files failed to download. They have been ignored, or old ones used instead.
#26 9.170 Reading package lists...
#26 11.46 Building dependency tree...
#26 11.92 Reading state information...
#26 12.21 E: Unable to locate package google-cloud-sdk
```