### PR TITLE
Update golang and driver versions.

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5.0.1
       with:
-        go-version: ^1.22
+        go-version: 1.21.x
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TEST_INFRA_VERSION ?= latest
 
 # Version of gRPC core used for the gRPC driver
-DRIVER_VERSION ?= v1.62.1
+DRIVER_VERSION ?= v1.68.0
 
 # Prefix for all images used as clone and ready containers, enabling use with
 # registries other than Docker Hub

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -27,7 +27,7 @@ languages:
   runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
-  buildImage: golang:1.22
+  buildImage: golang:1.23
   runImage: "{{ .RunImagePrefix }}go:{{ .Version }}"
 
 - language: java

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -27,7 +27,7 @@ languages:
   runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
-  buildImage: golang:1.20
+  buildImage: golang:1.22
   runImage: "{{ .RunImagePrefix }}go:{{ .Version }}"
 
 - language: java

--- a/containers/runtime/controller/Dockerfile
+++ b/containers/runtime/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.21 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
- Updates the go version for tests that do not use prebuilt images to go 1.23.
- Updates the go version for github actions to 1.21.x (build currently fails with go version >= 1.22.0).
- Updates the go version for the controller build to 1.21.
- Updates the driver version to (grpc) 1.68.0.