### PR TITLE
Fix for error in  building golang worker image for gRPC OSS benchmarks

### DIFF
--- a/containers/pre_built_workers/go/Dockerfile
+++ b/containers/pre_built_workers/go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22
+FROM golang:1.23 
 
 RUN mkdir -p /executable
 WORKDIR /executable


### PR DESCRIPTION
The golang version modified to 1.23 in golang worker image to fix build failures.