### PR TITLE
Move inactive maintainers to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,9 +11,9 @@ for general contribution guidelines.
 ## Maintainers (in alphabetical order)
 
 - [paulosjca](https://github.com/paulosjca), Google LLC
-- [wanlin31](https://github.com/wanlin31), Google LLC
-- [ybbbby](https://github.com/ybbbby), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
 
 - [codeblooded](https://github.com/codeblooded), Google LLC
+- [wanlin31](https://github.com/wanlin31), Google LLC
+- [ybbbby](https://github.com/ybbbby), Google LLC


### PR DESCRIPTION
This PR:
- Moves Wanlin Du (@wanlin31) to Emeritus
- Moves Donghao Qiu (@ybbbby) to Emeritus

This PR must remain open until July 10th 2025 to allow time for response.