### PR TITLE
Fix main and experimental benchmarks test failure

### DIFF
--- a/containers/init/build/dotnet/Dockerfile
+++ b/containers/init/build/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview
 
 RUN mkdir -p /pre
 WORKDIR /pre


### PR DESCRIPTION
Dotnet SDK version is updated in grpc-dotnet, and benchmarks tests are failing. 
Updated the SDK version.