### PR TITLE
fix benchmarks fail due to golang version update

### DIFF
--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -27,7 +27,7 @@ languages:
   runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
-  buildImage: golang:1.23
+  buildImage: golang:1.24
   runImage: debian:bookworm
 
 - language: java

--- a/containers/pre_built_workers/dotnet/Dockerfile
+++ b/containers/pre_built_workers/dotnet/Dockerfile
@@ -40,7 +40,7 @@ RUN dotnet publish -c Release -o qps_worker perf/benchmarkapps/QpsWorker/
 
 # Note that the QpsWorker built by "dotnet publish" in the previous step needs to be runnable
 # with the runtime image below.
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview
 
 # Enable dynamic profile-guided optimization
 # https://gist.github.com/EgorBo/dc181796683da3d905a5295bfd3dd95b

--- a/containers/pre_built_workers/go/Dockerfile
+++ b/containers/pre_built_workers/go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 
+FROM golang:1.24
 
 RUN mkdir -p /executable
 WORKDIR /executable

--- a/containers/runtime/dotnet/Dockerfile
+++ b/containers/runtime/dotnet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace


### PR DESCRIPTION
Updated the golang worker image version to 1.24, along with updating the dotnet/aspnet version to 10.0-preview.