### PR TITLE
Update Bazel base image for cxx worker to 8.7.0

### DIFF
--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -23,7 +23,7 @@ languages:
   runImage: "{{ .RunImagePrefix }}dotnet:{{ .Version }}"
 
 - language: cxx
-  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
   runImage: "{{ .RunImagePrefix }}cxx:{{ .Version }}"
 
 - language: go
@@ -47,11 +47,11 @@ languages:
   runImage: "{{ .RunImagePrefix }}php7:{{ .Version }}"
 
 - language: python
-  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
   runImage: "{{ .RunImagePrefix }}python:{{ .Version }}"
 
 - language: python_asyncio
-  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+  buildImage: us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
   runImage: "{{ .RunImagePrefix }}python:{{ .Version }}"
 
 - language: ruby

--- a/containers/pre_built_workers/cxx/Dockerfile
+++ b/containers/pre_built_workers/cxx/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md
-FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
 
 RUN mkdir -p /source/code
 WORKDIR /source/code

--- a/containers/pre_built_workers/python/Dockerfile
+++ b/containers/pre_built_workers/python/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md
-FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
 
 RUN mkdir -p /pre
 WORKDIR /pre
@@ -37,6 +37,8 @@ RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
 RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 
 RUN mkdir /executables
+
+
 RUN bazel --output_user_root=/executables build -c opt --nobuild_runfile_links --nobuild_runfile_manifests --build_python_zip //src/python/grpcio_tests/tests/qps:qps_worker
 RUN bazel --output_user_root=/executables build -c opt --nobuild_runfile_links --nobuild_runfile_manifests --build_python_zip //src/python/grpcio_tests/tests_aio/benchmark:worker
 

--- a/containers/runtime/driver/Dockerfile
+++ b/containers/runtime/driver/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/$REPOSITORY.git .
 RUN git checkout -f $GITREF
 
 # See https://github.com/grpc/grpc/blob/master/tools/dockerfile/README.md
-FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:17f63c84b86ac41f70f86cac931fffc785a474e0@sha256:814f79b30656de4627c88e53bbf1c457037748971055702a74745a5828de12fa
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:ac0cf07a320bb1f337986fd312a1785614cc1e4e@sha256:4b64295380d6c951f3761273344e256f44daab35dd7182ff431a1802695368da
 
 COPY --from=0 /src/code /src/code
 RUN mkdir -p /tmp/build_output


### PR DESCRIPTION
The bazel image v8.7.0 was updated in the Grpc repository last week (https://github.com/grpc/grpc/pull/42392). We are moving to this newer version because the previous 8.0.1 release caused compatibility issues.