### PR TITLE
Add support for gRPC Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ delete_prebuilt_workers: fmt vet ## Build the delete_prebuilt_workers tool binar
 
 ##@ Build container images
 
-all-images: clone-image controller-image csharp-build-image cxx-image dotnet-build-image dotnet-image driver-image java-image node-build-image node-image php7-build-image php7-image python-image ready-image ruby-build-image ruby-image ## Build all container images.
+all-images: clone-image controller-image csharp-build-image cxx-image dotnet-build-image dotnet-image driver-image java-image node-build-image node-image php7-build-image php7-image python-image ready-image ruby-build-image ruby-image rust-build-image ## Build all container images.
 
 clone-image: ## Build the clone init container image.
 	docker build -t $(INIT_IMAGE_PREFIX)clone:$(TEST_INFRA_VERSION) containers/init/clone
@@ -150,9 +150,12 @@ ruby-build-image: ## Build the Ruby build-time container image.
 ruby-image: ## Build the Ruby test runtime container image.
 	docker build -t $(RUN_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION) containers/runtime/ruby
 
+rust-build-image: ## Build the Rust build-time container image.
+	docker build -t $(BUILD_IMAGE_PREFIX)rust:$(TEST_INFRA_VERSION) containers/init/build/rust
+
 ##@ Publish container images
 
-push-all-images: push-clone-image push-controller-image push-csharp-build-image push-cxx-image push-dotnet-build-image push-dotnet-image push-driver-image push-java-image push-node-build-image push-node-image push-php7-build-image push-php7-image push-python-image push-ready-image push-ruby-build-image push-ruby-image ## Push all container images to a registry.
+push-all-images: push-clone-image push-controller-image push-csharp-build-image push-cxx-image push-dotnet-build-image push-dotnet-image push-driver-image push-java-image push-node-build-image push-node-image push-php7-build-image push-php7-image push-python-image push-ready-image push-ruby-build-image push-ruby-image push-rust-build-image ## Push all container images to a registry.
 
 push-clone-image: ## Push the clone init container image to a registry.
 	docker push $(INIT_IMAGE_PREFIX)clone:$(TEST_INFRA_VERSION)
@@ -201,6 +204,9 @@ push-ruby-build-image: ## Push the Ruby build-time container image to a registry
 
 push-ruby-image: ## Push the Ruby test runtime container image to a registry.
 	docker push $(RUN_IMAGE_PREFIX)ruby:$(TEST_INFRA_VERSION)
+
+push-rust-build-image: ## Push the Rust build-time container image to a registry.
+	docker push $(BUILD_IMAGE_PREFIX)rust:$(TEST_INFRA_VERSION)
 
 ##@ Build PSM related container images
 

--- a/config/defaults_template.yaml
+++ b/config/defaults_template.yaml
@@ -57,3 +57,7 @@ languages:
 - language: ruby
   buildImage: "{{ .BuildImagePrefix }}ruby:{{ .Version }}"
   runImage: "{{ .RunImagePrefix }}ruby:{{ .Version }}"
+
+- language: rust
+  buildImage: "{{ .BuildImagePrefix }}rust:{{ .Version }}"
+  runImage: debian:bookworm

--- a/config/samples/rust_example_loadtest.yaml
+++ b/config/samples/rust_example_loadtest.yaml
@@ -5,12 +5,12 @@ apiVersion: e2etest.grpc.io/v1
 kind: LoadTest
 metadata:
   annotations:
-    scenario: rust_generic_sync_streaming_ping_pong_secure
+    scenario: rust_protobuf_sync_streaming_ping_pong_secure
     uniquifier: basic
   labels:
     language: rust
     prefix: examples
-  name: examples-rust-generic-sync-streaming-ping-pong-secure-basic
+  name: examples-rust-protobuf-sync-streaming-ping-pong-secure-basic
 spec:
   clients:
   - build:
@@ -44,7 +44,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "rust_generic_sync_streaming_ping_pong_secure",
+        "name": "rust_protobuf_sync_streaming_ping_pong_secure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -66,7 +66,7 @@ spec:
           "channel_args": [
             {
               "name": "grpc.optimization_target",
-               "str_value": "latency"
+              "str_value": "latency"
             }
           ],
           "payload_config": {
@@ -80,7 +80,7 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
           "security_params": {
             "use_test_ca": true,
             "server_host_override": "foo.test.google.fr"
@@ -93,13 +93,7 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "simple_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
         "warmup_seconds": 5,
         "benchmark_seconds": 30

--- a/config/samples/rust_example_loadtest.yaml
+++ b/config/samples/rust_example_loadtest.yaml
@@ -24,8 +24,8 @@ spec:
       command:
       - cargo
     clone:
-      gitRef: grpc-benchmark-client
-      repo: https://github.com/arjan-bal/tonic.git
+      gitRef: master
+      repo: https://github.com/grpc/grpc-rust.git
     language: rust
     name: '0'
     run:
@@ -117,8 +117,8 @@ spec:
       command:
       - cargo
     clone:
-      gitRef: grpc-benchmark-client
-      repo: https://github.com/arjan-bal/tonic.git
+      gitRef: master
+      repo: https://github.com/grpc/grpc-rust.git
     language: rust
     name: '0'
     run:
@@ -132,4 +132,3 @@ spec:
       name: main
   timeoutSeconds: 900
   ttlSeconds: 86400
-

--- a/config/samples/rust_example_loadtest.yaml
+++ b/config/samples/rust_example_loadtest.yaml
@@ -1,0 +1,135 @@
+# Load test configurations generated from a template by loadtest_config.py.
+# See documentation below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md#grpc-oss-benchmarks
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  annotations:
+    scenario: rust_generic_sync_streaming_ping_pong_secure
+    uniquifier: basic
+  labels:
+    language: rust
+    prefix: examples
+  name: examples-rust-generic-sync-streaming-ping-pong-secure-basic
+spec:
+  clients:
+  - build:
+      args:
+      - build
+      - -p
+      - grpc-benchmark
+      - --release
+      - --bin
+      - worker
+      command:
+      - cargo
+    clone:
+      gitRef: grpc-benchmark-client
+      repo: https://github.com/arjan-bal/tonic.git
+    language: rust
+    name: '0'
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/target/release/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  driver:
+    language: cxx
+    name: '0'
+    run: []
+  scenariosJSON: |
+    {
+      "scenarios": {
+        "name": "rust_generic_sync_streaming_ping_pong_secure",
+        "num_servers": 1,
+        "num_clients": 1,
+        "client_config": {
+          "client_type": "SYNC_CLIENT",
+          "security_params": {
+            "use_test_ca": true,
+            "server_host_override": "foo.test.google.fr"
+          },
+          "outstanding_rpcs_per_channel": 1,
+          "client_channels": 1,
+          "async_client_threads": 1,
+          "client_processes": 0,
+          "threads_per_cq": 0,
+          "rpc_type": "STREAMING",
+          "histogram_params": {
+            "resolution": 0.01,
+            "max_possible": 60000000000.0
+          },
+          "channel_args": [
+            {
+              "name": "grpc.optimization_target",
+               "str_value": "latency"
+            }
+          ],
+          "payload_config": {
+            "simple_params": {
+              "req_size": 0,
+              "resp_size": 0
+            }
+          },
+          "load_params": {
+            "closed_loop": {}
+          }
+        },
+        "server_config": {
+          "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": {
+            "use_test_ca": true,
+            "server_host_override": "foo.test.google.fr"
+          },
+          "async_server_threads": 1,
+          "server_processes": 0,
+          "threads_per_cq": 0,
+          "channel_args": [
+            {
+              "name": "grpc.optimization_target",
+              "str_value": "latency"
+            }
+          ],
+          "payload_config": {
+            "simple_params": {
+              "req_size": 0,
+              "resp_size": 0
+            }
+          }
+        },
+        "warmup_seconds": 5,
+        "benchmark_seconds": 30
+      }
+    }
+  servers:
+  - build:
+      args:
+      - build
+      - -p
+      - grpc-benchmark
+      - --release
+      - --bin
+      - worker
+      command:
+      - cargo
+    clone:
+      gitRef: grpc-benchmark-client
+      repo: https://github.com/arjan-bal/tonic.git
+    language: rust
+    name: '0'
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/target/release/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  timeoutSeconds: 900
+  ttlSeconds: 86400
+

--- a/config/samples/templates/rust_example_loadtest_with_prebuilt_workers.yaml
+++ b/config/samples/templates/rust_example_loadtest_with_prebuilt_workers.yaml
@@ -1,0 +1,120 @@
+# Load test configurations generated from a template by loadtest_config.py.
+# See documentation below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md#grpc-oss-benchmarks
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  annotations:
+    pool: ${workers_pool}
+    scenario: rust_generic_sync_streaming_ping_pong_secure
+    uniquifier: prebuilt
+  labels:
+    language: rust
+    prefix: examples
+  name: examples-rust-generic-sync-streaming-ping-pong-secure-prebuilt
+spec:
+  clients:
+  - language: rust
+    name: '0'
+    pool: ${workers_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/rust:${prebuilt_image_tag}
+      name: main
+  driver:
+    language: cxx
+    name: '0'
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
+  scenariosJSON: |
+    {
+      "scenarios": {
+        "name": "rust_generic_sync_streaming_ping_pong_secure",
+        "num_servers": 1,
+        "num_clients": 1,
+        "client_config": {
+          "client_type": "SYNC_CLIENT",
+          "security_params": {
+            "use_test_ca": true,
+            "server_host_override": "foo.test.google.fr"
+          },
+          "outstanding_rpcs_per_channel": 1,
+          "client_channels": 1,
+          "async_client_threads": 1,
+          "client_processes": 0,
+          "threads_per_cq": 0,
+          "rpc_type": "STREAMING",
+          "histogram_params": {
+            "resolution": 0.01,
+            "max_possible": 60000000000.0
+          },
+          "channel_args": [
+            {
+              "name": "grpc.optimization_target",
+              "str_value": "latency"
+            }
+          ],
+          "payload_config": {
+            "simple_params": {
+              "req_size": 0,
+              "resp_size": 0
+            }
+          },
+          "load_params": {
+            "closed_loop": {}
+          }
+        },
+        "server_config": {
+          "server_type": "ASYNC_GENERIC_SERVER",
+          "security_params": {
+            "use_test_ca": true,
+            "server_host_override": "foo.test.google.fr"
+          },
+          "async_server_threads": 1,
+          "server_processes": 0,
+          "threads_per_cq": 0,
+          "channel_args": [
+            {
+              "name": "grpc.optimization_target",
+              "str_value": "latency"
+            }
+          ],
+          "payload_config": {
+            "simple_params": {
+              "req_size": 0,
+              "resp_size": 0
+            }
+          }
+        },
+        "warmup_seconds": 5,
+        "benchmark_seconds": 30
+      }
+    }
+  servers:
+  - language: rust
+    name: '0'
+    pool: ${workers_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/rust:${prebuilt_image_tag}
+      name: main
+  timeoutSeconds: 900
+  ttlSeconds: 86400

--- a/config/samples/templates/rust_example_loadtest_with_prebuilt_workers.yaml
+++ b/config/samples/templates/rust_example_loadtest_with_prebuilt_workers.yaml
@@ -6,12 +6,12 @@ kind: LoadTest
 metadata:
   annotations:
     pool: ${workers_pool}
-    scenario: rust_generic_sync_streaming_ping_pong_secure
+    scenario: rust_protobuf_sync_streaming_ping_pong_secure
     uniquifier: prebuilt
   labels:
     language: rust
     prefix: examples
-  name: examples-rust-generic-sync-streaming-ping-pong-secure-prebuilt
+  name: examples-rust-protobuf-sync-streaming-ping-pong-secure-prebuilt
 spec:
   clients:
   - language: rust
@@ -40,7 +40,7 @@ spec:
   scenariosJSON: |
     {
       "scenarios": {
-        "name": "rust_generic_sync_streaming_ping_pong_secure",
+        "name": "rust_protobuf_sync_streaming_ping_pong_secure",
         "num_servers": 1,
         "num_clients": 1,
         "client_config": {
@@ -76,7 +76,7 @@ spec:
           }
         },
         "server_config": {
-          "server_type": "ASYNC_GENERIC_SERVER",
+          "server_type": "SYNC_SERVER",
           "security_params": {
             "use_test_ca": true,
             "server_host_override": "foo.test.google.fr"
@@ -89,13 +89,7 @@ spec:
               "name": "grpc.optimization_target",
               "str_value": "latency"
             }
-          ],
-          "payload_config": {
-            "simple_params": {
-              "req_size": 0,
-              "resp_size": 0
-            }
-          }
+          ]
         },
         "warmup_seconds": 5,
         "benchmark_seconds": 30

--- a/containers/init/build/rust/Dockerfile
+++ b/containers/init/build/rust/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2026 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM rust:1-bookworm
+
+RUN mkdir -p /src/workspace
+WORKDIR /src/workspace
+
+RUN apt-get update && apt-get install -y \
+  cmake && \
+  apt-get clean
+
+CMD ["bash"]

--- a/containers/pre_built_workers/rust/Dockerfile
+++ b/containers/pre_built_workers/rust/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2026 gRPC authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM rust:1-trixie AS builder
+
+RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /executable
+WORKDIR /executable
+
+# TODO: arjan-bal - point to official repo once https://github.com/grpc/grpc-rust/pull/2737
+# is merged.
+ARG REPOSITORY=arjan-bal/tonic
+ARG GITREF=grpc-benchmark-client
+# when BREAK_CACHE arg is set to a random value (e.g. by "--build-arg BREAK_CACHE=$(uuidgen)"),
+# it makes sure the docker cache breaks at this command, and all the following
+# commands in this Dockerfile will be forced to re-run on each build.
+# This is important to ensure we always clone the repository even if "GITREF" stays unchanged
+# (important e.g. when GITREF=master, when the clone command could get cached and
+# we'd end up with a stale repository).
+ARG BREAK_CACHE
+
+RUN git clone https://github.com/$REPOSITORY.git .
+RUN git checkout $GITREF
+
+# Save commit sha for debug use
+RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
+RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
+
+RUN  cargo build -p grpc-benchmark --release --bin worker
+
+# Copy go executable to a new image
+FROM debian:bookworm
+
+RUN mkdir -p /executable
+WORKDIR /executable
+COPY --from=0 /executable/GRPC_GIT_COMMIT.txt /executable/GRPC_GIT_COMMIT.txt
+COPY --from=0 /executable/target/release/worker /executable/bin/worker
+
+CMD ["bash"]

--- a/containers/pre_built_workers/rust/Dockerfile
+++ b/containers/pre_built_workers/rust/Dockerfile
@@ -40,7 +40,7 @@ RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 
 RUN  cargo build -p grpc-benchmark --release --bin worker
 
-# Copy go executable to a new image
+# Copy executable to a new image
 FROM debian:bookworm
 
 RUN mkdir -p /executable

--- a/containers/pre_built_workers/rust/Dockerfile
+++ b/containers/pre_built_workers/rust/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1-trixie AS builder
+FROM rust:1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/containers/pre_built_workers/rust/Dockerfile
+++ b/containers/pre_built_workers/rust/Dockerfile
@@ -19,10 +19,8 @@ RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /executable
 WORKDIR /executable
 
-# TODO: arjan-bal - point to official repo once https://github.com/grpc/grpc-rust/pull/2737
-# is merged.
-ARG REPOSITORY=arjan-bal/tonic
-ARG GITREF=grpc-benchmark-client
+ARG REPOSITORY=grpc/grpc-rust
+ARG GITREF=master
 # when BREAK_CACHE arg is set to a random value (e.g. by "--build-arg BREAK_CACHE=$(uuidgen)"),
 # it makes sure the docker cache breaks at this command, and all the following
 # commands in this Dockerfile will be forced to re-run on each build.
@@ -38,7 +36,7 @@ RUN git checkout $GITREF
 RUN echo 'COMMIT SHA' > GRPC_GIT_COMMIT.txt
 RUN git rev-parse $GITREF >> GRPC_GIT_COMMIT.txt
 
-RUN  cargo build -p grpc-benchmark --release --bin worker
+RUN cargo build -p grpc-benchmark --release --bin worker
 
 # Copy executable to a new image
 FROM debian:bookworm


### PR DESCRIPTION
Contributes to: https://github.com/grpc/grpc-rust/issues/2666

This change adds support for running both pre-built and on-the-fly benchmarks using the new gRPC Rust clients and servers.

## Tested

* Pre-built tests: Verified that the sample load test runs successfully using a development image tag.
* On-the-fly tests: Deployed the built operator to the `benchmarks-dev1` cluster and verified that the sample load test runs successfully.

A follow-up PR will be raised for a new `test-infra` release.