### PR TITLE
Fix build for java, cxx, init clone and driver images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TEST_INFRA_VERSION ?= latest
 
 # Version of gRPC core used for the gRPC driver
-DRIVER_VERSION ?= v1.68.0
+DRIVER_VERSION ?= v1.82.1
 
 # Prefix for all images used as clone and ready containers, enabling use with
 # registries other than Docker Hub

--- a/containers/init/clone/Dockerfile
+++ b/containers/init/clone/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y git && apt-get clean
 

--- a/containers/runtime/cxx/Dockerfile
+++ b/containers/runtime/cxx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace

--- a/containers/runtime/java/Dockerfile
+++ b/containers/runtime/java/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:11
+FROM eclipse-temurin:11-jdk-jammy
 
 RUN mkdir -p /src/workspace
 WORKDIR /src/workspace


### PR DESCRIPTION
This PR fixes broken docker image builds in preparation for a minor release for adding gRPC Rust support (https://github.com/grpc/test-infra/pull/423).

## Tested
Verified that on-the-fly tests pass for CPP, Java with the new driver image.